### PR TITLE
Only try to run gperf if it's present

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -127,18 +127,14 @@ local.c: local.dst
 ../po/pennmush.pot: $(C_FILES)
 	xgettext -d pennmush -kT -o ../po/pennmush.pot $(C_FILES)
 
-# The following source files are auto-generated with gperf.
-bflags.c: bflags.gperf
-	gperf -C --output-file bflags.c bflags.gperf
-
-htmltab.c: htmltab.gperf
-	gperf -C --output-file htmltab.c htmltab.gperf
-
-lmathtab.c: lmathtab.gperf
-	gperf -C --output-file lmathtab.c lmathtab.gperf
-
-rgbtab.c: rgbtab.gperf
-	gperf -C --output-file rgbtab.c rgbtab.gperf
+# Use gperf to auto-generate these files, if it's present.
+GPERF_FILES=bflags.c htmltab.c lmathtab.c rgbtab.c
+$(GPERF_FILES): %.c: %.gperf
+	@if command -v gperf &> /dev/null; then \
+		gperf -C --output-file $@ $<; \
+	else \
+		echo "*** NOTE ***: src/$@ appears to be out of date, but you don't have gperf installed. Install gperf or touch src/$@ to suppress this message."; \
+	fi
 
 etags: 
 	@ETAGS@ *.c ../hdrs/*.h


### PR DESCRIPTION
Per conversation with @talvo, this changeset removes a compile-time dependency on `gperf`. This is relevant because currently, when you get a fresh clone and try to `make`, all of the `src/*.gperf` files are infinitesimally newer than their corresponding .c files, since the clone sets mod dates lexicographically. If you don't have `gperf` installed, your compile then fails, even though those flies are up-to-date.