### PR TITLE
fixed typo in tag/endtag/tagwrap

### DIFF
--- a/src/markup.c
+++ b/src/markup.c
@@ -361,7 +361,7 @@ FUNCTION(fun_tag)
 {
   int i;
   if (!Can_Pueblo_Send(executor)
-      && !is_allowed_tag(args[0], arglens[0])) {
+      || !is_allowed_tag(args[0], arglens[0])) {
     safe_str("#-1", buff, bp);
     return;
   }
@@ -380,7 +380,7 @@ FUNCTION(fun_tag)
 /* ARGSUSED */
 FUNCTION(fun_endtag)
 {
-  if (!Can_Pueblo_Send(executor) && !is_allowed_tag(args[0], arglens[0]))
+  if (!Can_Pueblo_Send(executor) || !is_allowed_tag(args[0], arglens[0]))
     safe_str("#-1", buff, bp);
   else
     safe_tag_cancel(args[0], buff, bp);
@@ -389,7 +389,7 @@ FUNCTION(fun_endtag)
 /* ARGSUSED */
 FUNCTION(fun_tagwrap)
 {
-  if (!Can_Pueblo_Send(executor) && !is_allowed_tag(args[0], arglens[0]))
+  if (!Can_Pueblo_Send(executor) || !is_allowed_tag(args[0], arglens[0]))
     safe_str("#-1", buff, bp);
   else {
     if (nargs == 2)


### PR DESCRIPTION
There was a typo in fun_tag, fun_endtag, and fun_tagwrap that allowed anyone to use those functions without the Pueblo power as long as it was also a valid tag. It would also allow anyone with the pueblo power to use a non-allowed tag although just the attributes are returned. The conditional && was changed to || so that a failure occurs when either the permissions are absent or the tag is invalid.