### PR TITLE
Add avg() -> mean() alias for Rhost compatibility.

### DIFF
--- a/CHANGES.186
+++ b/CHANGES.186
@@ -36,6 +36,7 @@ Functions:
    for convtime(). Suggested by Volund. [1010-MG]
  * convsecs() can now accept negative inputs when Extended convtime() is
    available. Suggested by Volund. [1010-MG]
+ * avg() is now an alias for mean(). [1023-TK] [Rhost]
 
 Commands:
  * Remove ancient @channel foo=on behavior. Reported by Paige. [870-TK]

--- a/game/txt/hlp/pennfunc.hlp
+++ b/game/txt/hlp/pennfunc.hlp
@@ -3308,11 +3308,13 @@ See also: regmatch(), regrab(), match(), REGEXP SYNTAX
   It can take any number of arguments.
   
 See also: min(), lmath(), bound(), alphamax()
+& AVG()
 & MEAN()
   mean(<number1>, <number2>[, ... , <numberN>])
 
   Returns the mean (arithmetic average) of its arguments.
 
+  avg() is an alias for mean(), for Rhost compatibility.
 See also: median(), stddev(), lmath()
 & MEDIAN()
   median(<number>, <number>[, ... , <numberN>)

--- a/game/txt/hlp/pennv186.hlp
+++ b/game/txt/hlp/pennv186.hlp
@@ -31,6 +31,7 @@ Functions:
    for convtime(). Suggested by Volund. [1010-MG]
  * convsecs() can now accept negative inputs when Extended convtime() is
    available. Suggested by Volund. [1010-MG]
+ * avg() is now an alias for mean(). [1023-TK] [Rhost]
 
 Commands:
  * Remove ancient @channel foo=on behavior. Reported by Paige. [870-TK]

--- a/src/function.c
+++ b/src/function.c
@@ -152,7 +152,8 @@ FUNALIAS faliases[] = {
   {"STRDELETE", "DELETE"},
   {"LREPLACE", "REPLACE"},
   {"LINSERT", "INSERT"},
-  {"MONIKER", "CNAME"},         /* Rhost alias */
+  {"MONIKER", "CNAME"},  /* Rhost alias */
+  {"MEAN", "AVG"},  /* Rhost alias */
   {"MATCH", "ELEMENT"},
   {NULL, NULL}
 };


### PR DESCRIPTION
Last hardcode element of #1023.