### PR TITLE
str_type() wasn't checking for ansi escape codes

### DIFF
--- a/src/notify.c
+++ b/src/notify.c
@@ -268,7 +268,7 @@ str_type(const char *str)
   type &= ~(MSG_PUEBLO | MSG_STRIPACCENTS);
 #endif                          /* CHECK_FOR_HTML */
 
-  if (strstr(str, MARKUP_START "c") == NULL) {
+  if (strstr(str, MARKUP_START "c") == NULL && strchr(str, ESC_CHAR) == NULL) {
     /* No ANSI */
     type &= ~(MSG_ANSI2 | MSG_ANSI16 | MSG_XTERM256);
   }


### PR DESCRIPTION
Fixes issue #1050 
str_type() was setting the string to non ansi type if it didn't find markup, should check for ansi ESC_CHAR as well.