### PR TITLE
CI: Install gperf through the apt addon instead of using apt-get.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: c
 compiler: gcc
 before_install:
-  - sudo apt-get install -qq gperf
   - locale
 before_script:
   - ./configure
   - yes "" | make update
   - make
 script: make test
+addons:
+  apt:
+    packages:
+      - gperf


### PR DESCRIPTION
travis-ci updated their build infrastructure and doesn't let you use sudo anymore; just as well, as there's now a declarative syntax for providing the packages we need.

cc @talvo 