### PR TITLE
Fix incorrect reference in the @hook2 helpentry.

### DIFF
--- a/game/txt/hlp/penncmd.hlp
+++ b/game/txt/hlp/penncmd.hlp
@@ -1586,7 +1586,7 @@ See also: enter, @enter, ENTER_OK, @describe, look, @idescformat, VERBS
 & @hook2
   In all cases, %# is the dbref of the object doing the command, and all hooks share the same set of q-registers. With /before and /after, the results of the evaluated attribute is thrown away like it was wrapped in a call of null(). Also, in cases where a command and function do the same thing (e.g., @pemit and pemit()), only the command gets the hooks.
   
-  A number of named registers are available in @hooks, accessible via r(<name>, args), containing the arguments passed to the command. The exact registers available depend on the command type and the arguments passed; see 'help @hook6' for a description of all possible registers.
+  A number of named registers are available in @hooks, accessible via r(<name>, args), containing the arguments passed to the command. The exact registers available depend on the command type and the arguments passed; see 'help @hook7' for a description of all possible registers.
   
   Hooks can also be set in the alias.cnf file.
 


### PR DESCRIPTION
The @hook2 help entry referenced the @hook6 help entry for a list of named arguments, however, the list is actually in @hook7.