### PR TITLE
Add email to PLAYER`CREATE event

### DIFF
--- a/CHANGES.186
+++ b/CHANGES.186
@@ -15,7 +15,7 @@ Numbers next to the developer credit refer to Github issue numbers.
 Version 1.8.6 patchlevel 1                                 ??? ??, 2016
 
 Minor changes:
-* PLAYER`CREATE event now passes the registered email if the player was created using 'register' at the login screen. PR by Qon.
+ * PLAYER`CREATE event now passes the registered email if the player was created using 'register' at the login screen. PR by Qon.
  * moniker() now returns accented names, for Rhost/MUX compatability. Reported by Qon. [1063-MG]
  * Help fixes by Qon and others. [MG]
 

--- a/CHANGES.186
+++ b/CHANGES.186
@@ -15,6 +15,7 @@ Numbers next to the developer credit refer to Github issue numbers.
 Version 1.8.6 patchlevel 1                                 ??? ??, 2016
 
 Minor changes:
+* PLAYER`CREATE event now passes the registered email if the player was created using 'register' at the login screen. PR by Qon.
  * moniker() now returns accented names, for Rhost/MUX compatability. Reported by Qon. [1063-MG]
  * Help fixes by Qon and others. [MG]
 

--- a/game/txt/hlp/pennevents.hlp
+++ b/game/txt/hlp/pennevents.hlp
@@ -137,8 +137,8 @@ No arguments are passed to these events.
   &SIGNAL`USR1 Event Handler=@nspemit/list lwho()=GAME: Reboot w/o disconnect from game account, please wait. ; @shutdown/reboot
   &SIGNAL`USR2 Event Handler=@dump
 & EVENT PLAYER
-  player`create (objid, name, how, descriptor)
-      Triggered when a player is created. If the player was @pcreated, then %# will be the person who did the @pcreate. If player was created by using 'create' at the connect screen, then %# will be #-1 and <descriptor> will be non-null. <how> is one of: "pcreate", "create" or "register".
+  player`create (objid, name, how, descriptor, email)
+      Triggered when a player is created. If the player was @pcreated, then %# will be the person who did the @pcreate. If player was created by using 'create' at the connect screen, then %# will be #-1 and <descriptor> will be non-null. <how> is one of: "pcreate", "create" or "register". If created using 'register', <email> will be set appropriately.
 
   player`connect (objid, number of connections, descriptor)
       Similar to @aconnect, but for events, and so you can use descriptor.

--- a/src/player.c
+++ b/src/player.c
@@ -538,8 +538,8 @@ email_register_player(DESC *d, const char *name, const char *email,
   } else {
     /* Ok, all's well, make a player */
     player = make_player(name, passwd, host, ip);
-    queue_event(SYSEVENT, "PLAYER`CREATE", "%s,%s,%s,%d",
-                unparse_objid(player), name, "register", d->descriptor);
+    queue_event(SYSEVENT, "PLAYER`CREATE", "%s,%s,%s,%d,%s",
+                unparse_objid(player), name, "register", d->descriptor, email);
     (void) atr_add(player, "REGISTERED_EMAIL", email, GOD, 0);
     return player;
   }


### PR DESCRIPTION
If using register at the login screen, pass the email to the event.