### PR TITLE
Fix do_second, crashing in socket`connect event

### DIFF
--- a/CHANGES.186
+++ b/CHANGES.186
@@ -21,6 +21,7 @@ Fixes:
  * Fixed a memory leak in @listens. [MG]
  * Minor align() fixes when merging multiple columns. [MG]
  * repeat() would sometimes fill the buffer with very large numbers of repetitions. Reported by Ashen-Shugar. [MG]
+ * SOCKET`CONNECT event caused a crash because cque expected a player to always be enactor. [GM]
 
 Minor changes:
  * PLAYER`CREATE event now passes the registered email if the player was created using 'register' at the login screen. PR by Qon.

--- a/src/cque.c
+++ b/src/cque.c
@@ -970,7 +970,7 @@ do_second(void)
     qwait = point->next;
     point->next = NULL;
     point->wait_until = 0;
-    if (IsPlayer(point->enactor)) {
+    if ((point->enactor < 0) || IsPlayer(point->enactor)) {
       if (qlast) {
         qlast->next = point;
         qlast = point;


### PR DESCRIPTION
Enactor on a socket`connect event is -1. This confuses cque.c. So this PR fixes it.