### PR TITLE
CI: Install IO::Socket::IP prior to running tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ before_script:
   - ./configure
   - yes "" | make update
   - make
+  - cpan install IO::Socket::IP
 script: make test
+env:
+  global:
+    - PERL_MM_USE_DEFAULT=1 # tell CPAN to assume defaults as much as possible
+    - PERL5LIB=/home/travis/perl5
 addons:
   apt:
     packages:


### PR DESCRIPTION
7359b25f877fe3818d1a19f95ed7642e9ed73cb7 introduced a dependency in the tests on the Perl `IO::Socket::IP` module, so that needs to be explicitly installed prior to running tests.