### PR TITLE
CI: More perl dependency fixage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script: make test
 env:
   global:
     - PERL_MM_USE_DEFAULT=1 # tell CPAN to assume defaults as much as possible
-    - PERL5LIB=/home/travis/perl5
+    - PERL5LIB=/home/travis/perl5/lib/perl5
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ before_script:
   - ./configure
   - yes "" | make update
   - make
-  - cpan install IO::Socket::IP
+  - curl -L https://cpanmin.us/ -o cpanm && chmod +x cpanm
+  - ./cpanm IO::Socket::IP
 script: make test
 env:
   global:

--- a/test/PennMUSH.pm
+++ b/test/PennMUSH.pm
@@ -6,7 +6,7 @@ use File::Path;
 use MUSHConnection;
 use POSIX qw/:sys_wait_h/;
 use feature qw/say/;
-no warnings qw/experimental::smartmatch/;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch'; # Don't blow up on Perls older than 5.18
 
 my @pids = ();
 


### PR DESCRIPTION
Includes a small tweak to the test suite to not break on Perls older than 5.18.