### PR TITLE
Add MUX comsys aliases. You can all stop asking for it, now.

### DIFF
--- a/CHANGES.186
+++ b/CHANGES.186
@@ -14,6 +14,9 @@ Numbers next to the developer credit refer to Github issue numbers.
 
 Version 1.8.6 patchlevel 1                                 ??? ??, 2016
 
+Major changes:
+ * Added some aliases for the MUX com system, including the addcom, delcom, comtitle, comlist and @clist commands. Enabled by adding #define MUXCOMM to options.h. See 'help muxcomsys' for details. Requested by many people over the years. [MG]
+
 Fixes:
  * @clone'ing an old exit which had the alias built into the name incorrectly created a clone with no aliases. Reported by Qon. [MG]
  * Fix compile errors in portmsg.c. Reported by mcgiwer. [SW]

--- a/game/txt/hlp/pennchat.hlp
+++ b/game/txt/hlp/pennchat.hlp
@@ -11,6 +11,8 @@
   You can list, join, and configure channels using the @channel command.
 
   To speak on channels, use the @chat command.
+  
+  There are some aliases in place for players more familiar with the MUX comsys - see 'help muxcomsys' for more details.
 
 See also: @channel, @chat, @cemit, channel functions, CHAN_USEFIRSTMATCH,
   @chatformat, @clock
@@ -517,3 +519,42 @@ See also: @channel/mogrifier, @chatformat, channel functions
   cwho()        nscemit()
 
 See also: CHAT, @channel, @cemit, @clock
+& MUXCOMSYS
+& ADDCOM
+& DELCOM
+& @CLIST
+& COMTITLE
+& COMLIST
+  PennMUSH offers some compatability commands for players more familiar with the MUX communication system. For help on PennMUSH's channel system, see 'help channels'. The following commands are defined:
+  
+  addcom <alias>=<channel>
+    Join <channel> if you aren't already on it, and add <alias> as an alias for <channel>.
+  <alias> WHO
+    Alias for @channel/who <channel>
+  <alias> OFF
+    Alias for @channel/gag <channel>
+  <alias> ON
+    Alias for @channel/ungag <channel>
+  <alias> <message>
+    Say <message> on the channel matching <alias>. Does not evaluate <message>. Equivilent to +<channel> <message>.
+  delcom <alias>
+    Deletes the alias <alias> and, if it's the last alias you have for the matching channel, leave the channel.
+  @clist[/full]
+    List all channels. Alias of @channel/list. /full does nothing.
+  comtitle <alias>=<title>
+    Alias of @channel/title <channel>=<title>
+  comlist
+    Lists all aliases and their matching channels.
+
+  See 'help muxcommsys2' for how to enable MUX com aliases.
+  See also: CHANNELS, @channel, @chat
+& MUXCOMSYS2
+  To enable the MUX comsys aliases in the hardcode, add:
+    #define MUXCOMM
+  to your options.h file, and then recompile the MUSH and @shutdown/reboot.
+  
+  Aliases are stored by "addcom" in attributes on the player, in the format
+  
+    &CHANALIAS`<alias> <player>=<channel-name>
+
+  Aliases are checked on parents, so you can add them to your ancestor player to have them usable by everyone.

--- a/game/txt/hlp/pennv186.hlp
+++ b/game/txt/hlp/pennv186.hlp
@@ -13,6 +13,9 @@ be read in 'help patchlevels'.
 
 Version 1.8.6 patchlevel 1                                 ??? ??, 2016
 
+Major changes:
+ * Added some aliases for the MUX com system, including the addcom, delcom, comtitle, comlist and @clist commands. Enabled by adding #define MUXCOMM to options.h. See 'help muxcomsys' for details. Requested by many people over the years. [MG]
+
 Fixes:
  * @clone'ing an old exit which had the alias built into the name incorrectly created a clone with no aliases. Reported by Qon. [MG]
  * Fix compile errors in portmsg.c. Reported by mcgiwer. [SW]

--- a/options.h.dist
+++ b/options.h.dist
@@ -49,6 +49,14 @@
  */
 /* #define CHAT_TOKEN_ALIAS '=' /* */
 
+/* Would you like to enable MUX-style channel aliases? These are
+ * wrappers for Penn's @channel system to provide more familiar syntax
+ * for MUX users, such as 'addcom <alias>=<channel>', then
+ * '<alias> <message> for chatting instead of '+<channel> <message>';
+ * see 'help muxcomsys' for more details.
+ * Would you like to enable the MUX aliases?
+/* #define MUXCOMM 1 /* */
+
 
 /*------------------------- Cosmetic Features --------------------*/
 

--- a/src/atr_tab.c
+++ b/src/atr_tab.c
@@ -1111,10 +1111,18 @@ attr_init_postconfig(void)
   ATTR *a;
   /* read_remote_desc affects AF_NEARBY flag on DESCRIBE attribute */
   a = aname_hash_lookup("DESCRIBE");
-  if (!a)
-    return;
-  if (READ_REMOTE_DESC)
-    a->flags &= ~AF_NEARBY;
-  else
-    a->flags |= AF_NEARBY;
+  if (a) {
+    if (READ_REMOTE_DESC)
+      a->flags &= ~AF_NEARBY;
+    else
+      a->flags |= AF_NEARBY;
+  }
+
+#ifdef MUXCOMM
+  a = aname_hash_lookup("CHANALIAS");
+  if (!a) {
+    add_new_attr("CHANALIAS", AF_NOPROG);
+  }
+#endif
+
 }

--- a/src/extchat.c
+++ b/src/extchat.c
@@ -90,6 +90,10 @@ static const char chan_mod_lock[] = "ChanModLock";      /**< Name of modify lock
 static const char chan_see_lock[] = "ChanSeeLock";      /**< Name of see lock */
 static const char chan_hide_lock[] = "ChanHideLock";    /**< Name of hide lock */
 
+#ifdef MUXCOMM
+char *parse_chat_alias(dbref player, char *command);
+#endif
+
 slab *chanlist_slab; /**< slab for 'struct chanlist' allocations */
 slab *chanuser_slab; /**< slab for 'struct chanuser' allocations */
 
@@ -1491,7 +1495,6 @@ parse_chat(dbref player, char *command)
     return 0;
   }
 }
-
 
 /** Chat on a channel, given its name.
  * \verbatim
@@ -4184,3 +4187,222 @@ eval_chan_lock(CHAN *c, dbref p, enum clock_type type)
   free_pe_info(pe_info);
   return retval;
 }
+
+#ifdef MUXCOMM
+/* Parse a "channel_alias message" into "real_channel_name=message"
+ * Used for MUX-style channel aliases
+ */
+char *parse_chat_alias(dbref player, char *command)
+{
+  char *alias;
+  char *message;
+  char *bp;
+  char channame[BUFFER_LEN];
+  char save;
+  char *av;
+  ATTR *a;
+  CHAN *c;
+  bool chat = 0;
+
+  alias = bp = command;
+  while (*bp && !isspace((unsigned char) *bp))
+    bp++;
+
+  if (!*bp)
+    return NULL;
+
+  save = *bp;
+  message = bp;
+  *message++ = '\0';
+  while (*message && isspace((unsigned char) *message))
+    message++;
+
+  strcpy(channame, alias);
+  upcasestr(channame);
+  a = atr_get(player, tprintf("CHANALIAS`%s", channame));
+  if (!a || !(av = safe_atr_value(a, "chanalias"))) {
+    /* Not an alias */
+    *bp = save;
+    return NULL;
+  }
+
+  switch (find_channel_partial_on(av, &c, player)) {
+    case CMATCH_EXACT:
+      bp = command;
+      /* If message is "on", "off", or "who", it's not speech, it's @chan/ungag,
+       * @chan/gag, or @chan/who, respectively */
+      if (!strcasecmp("on", message)) {
+        safe_format(command, &bp, "/ungag %s", av);
+      } else if (!strcasecmp("off", message)) {
+        safe_format(command, &bp, "/gag %s", av);
+      } else if (!strcasecmp("who", message)) {
+        safe_format(command, &bp, "/who %s", av);
+      } else {        
+        safe_format(command, &bp, "%s=%s", av, message);
+        chat = 1;
+      }
+      *bp = '\0';
+      mush_free(av, "chanalias");
+      if (chat)
+        return "@CHAT";
+      else
+        return "@CHANNEL";
+    default:
+      *bp = save;
+      mush_free(av, "chanalias");
+      return NULL;
+  }
+}
+
+COMMAND(cmd_addcom) {
+  char buff[BUFFER_LEN];
+  char *bp = buff;
+  ATTR *a;
+  CHAN *chan = NULL;
+
+  if (!arg_left || !*arg_left || strchr(arg_left, '`') || strlen(arg_left) > 15) {
+    notify(executor, T("Invalid alias."));
+    return;
+  }
+  safe_format(buff, &bp, "CHANALIAS`%s", arg_left);
+  *bp = '\0';
+  upcasestr(buff);
+  if (!good_atr_name(buff)) {
+    notify(executor, T("Invalid alias."));
+    return;
+  }
+  a = atr_get_noparent(executor, buff);
+  if (a) {
+    notify(executor, T("That alias is already in use."));
+    return;
+  }
+  switch (find_channel(arg_right, &chan, executor)) {
+  case CMATCH_NONE:
+    notify(executor, T("I don't recognise that channel."));
+    return;
+  case CMATCH_AMBIG:
+    notify(executor, T("I don't know which channel you mean."));
+    list_partial_matches(executor, arg_right, PMATCH_ALL);
+    return;
+  default:
+    break;
+  }
+  if (!Chan_Can_See(chan, executor)) {
+    notify(executor, T("I don't recognise that channel."));
+    return;
+  }
+  if (!onchannel(executor, chan)) {
+    /* Not currently on channel; try and join them to it */
+    channel_join_self(executor, ChanName(chan));
+  }
+  if (!onchannel(executor, chan)) {
+    /* Still not on it? You can't join. channel_join_self will have told you so */
+    return;
+  }
+  atr_add(executor, buff, normalize_channel_name(ChanName(chan)), GOD, 0);
+  notify_format(executor, T("Alias %s added for channel <%s>."), arg_left, ChanName(chan));
+}
+static int
+delcom_helper(dbref player __attribute__ ((__unused__)), dbref thing __attribute__ ((__unused__)), dbref parent __attribute__ ((__unused__)), const char *pattern __attribute__ ((__unused__)), ATTR *atr, void *args);
+
+static int
+delcom_helper(dbref player __attribute__ ((__unused__)), dbref thing __attribute__ ((__unused__)), dbref parent __attribute__ ((__unused__)), const char *pattern __attribute__ ((__unused__)), ATTR *atr, void *args)
+{
+  if (!strcasecmp(atr_value(atr), (char *)args))
+    return 1;
+  return 0;
+}
+
+COMMAND(cmd_delcom) {
+  char buff[BUFFER_LEN];
+  char *bp = buff;
+  ATTR *a;
+  char *channame;
+  int matches;
+  
+  safe_format(buff, &bp, "CHANALIAS`%s", arg_left);
+  *bp = '\0';
+  upcasestr(buff);
+  a = atr_get_noparent(executor, buff);
+  if (!a) {
+    notify(executor, T("No such alias."));
+    return;
+  }
+  channame = safe_atr_value(a, "delcom");
+
+  atr_clr(executor, buff, GOD);
+  matches = atr_iter_get(GOD, executor, "CHANALIAS`*", 0, 0, delcom_helper, channame);
+  if (!matches) {
+    channel_leave_self(executor, channame);
+  } else {
+    notify(executor, T("Alias removed."));
+  }
+  mush_free(channame, "delcom");
+}
+
+static int comlist_helper(dbref player __attribute__ ((__unused__)), dbref thing __attribute__ ((__unused__)), dbref parent __attribute__ ((__unused__)), const char *pattern __attribute__ ((__unused__)), ATTR *atr, void *args);
+
+static int
+comlist_helper(dbref player __attribute__ ((__unused__)), dbref thing, dbref parent __attribute__ ((__unused__)), const char *pattern __attribute__ ((__unused__)), ATTR *atr, void *args __attribute__ ((__unused__))) 
+{
+  CHAN *c;
+  CHANUSER *cu;
+  char buff[BUFFER_LEN];
+  char *bp;
+  char channame[BUFFER_LEN];
+  char *cn = channame;
+  int namelen;
+  
+  if (find_channel(atr_value(atr), &c, thing) != CMATCH_EXACT)
+    return 0;
+  
+  if (!(cu = onchannel(thing, c)))
+    return 0;
+  
+  mush_strncpy(buff, strlower(AL_NAME(atr)), BUFFER_LEN);
+  bp = strchr(buff, '`');
+  if (!bp)
+    return 0;
+  bp++;
+  if (!*bp)
+    return 0;
+  safe_str(ChanName(c), channame, &cn);
+  *cn = '\0';
+  namelen = ansi_strlen(channame);
+  if (namelen < 30) {
+    safe_fill(' ', 30 - namelen, channame, &cn);
+    *cn = '\0';
+  }
+  notify_format(thing, "%-18s %s %-8s %s", bp, channame, Chanuser_Gag(cu) ? "Off" : "On", CUtitle(cu) ? CUtitle(cu) : "");
+  return 1;
+}
+
+COMMAND(cmd_comlist) {
+  notify_format(executor, "%-18s %-30s %-8s %s", T("Alias"), T("Channel"),
+                T("Status"), T("Title"));
+  atr_iter_get(GOD, executor, "CHANALIAS`*", 0, 0, comlist_helper, NULL);
+  notify(executor, T("-- End of comlist --"));
+}
+
+COMMAND(cmd_clist) {
+  do_channel_list(executor, arg_left, CHANLIST_ALL);
+}
+
+COMMAND(cmd_comtitle) {
+  char buff[BUFFER_LEN];
+  char *bp = buff;
+  ATTR *a;
+  
+  safe_format(buff, &bp, "CHANALIAS`%s", arg_left);
+  *bp = '\0';
+  upcasestr(buff);
+  a = atr_get_noparent(executor, buff);
+  if (!a) {
+    notify_format(executor, T("No such alias '%s'."), arg_left);
+    return;
+  }
+  mush_strncpy(buff, atr_value(a), BUFFER_LEN);
+  do_chan_title(executor, buff, arg_right);
+}
+
+#endif


### PR DESCRIPTION
Adds aliases for the MUX channel system, including the commands:
```
addcom
delcom
comlist
comtitle
@clist
```
See `help muxcomsys` for details. 