### PR TITLE
Add handling of GET requests for MUSH info via JSON. Issue #1093.

### DIFF
--- a/hdrs/conf.h
+++ b/hdrs/conf.h
@@ -61,6 +61,7 @@
 
 #define GET_COMMAND "GET" /**< The GET command, for recognising browsers */
 #define POST_COMMAND "POST" /**< The POST command, for recognising browsers */
+#define REST_URL_PREFIX "/REST/" /**< The URL prefix for REST requests sent by browsers */
 
 #define PREFIX_COMMAND "OUTPUTPREFIX" /**< The OUTPUTPREFIX command */
 #define SUFFIX_COMMAND "OUTPUTSUFFIX" /**< The OUTPUTSUFFIX command */
@@ -315,6 +316,8 @@ struct options_table {
   int log_max_size; /**< Maximum size of log file */
   char log_size_policy[256]; /**< What to do when a log file is big. */
   char sendmail_prog[256]; /**< Program used to send email. */
+  dbref rest_object; /**< Dbref to send HTTP GET poll requests to */
+  char rest_attr[256]; /**< Attr to send HTTP GET poll requests to */
 };
 
 typedef struct mssp MSSP;

--- a/hdrs/externs.h
+++ b/hdrs/externs.h
@@ -85,6 +85,7 @@ JSON *string_to_json_real(char *input, char **ip, int recurse);
 #define string_to_json(in) string_to_json_real(in, NULL, 0)
 char *json_unescape_string(char *input);
 char *json_escape_string(char *input);
+JSON *json_alloc(int type);
 void json_free(JSON *json);
 void register_gmcp_handler(char *package, gmcp_handler_func func);
 void send_oob(DESC *d, char *package, JSON *data);

--- a/hdrs/mushtype.h
+++ b/hdrs/mushtype.h
@@ -405,13 +405,23 @@ struct descriptor_data {
 };
 
 
-enum json_type { JSON_NONE =
-    0, JSON_NUMBER, JSON_STR, JSON_BOOL, JSON_NULL, JSON_ARRAY, JSON_OBJECT
-};
+
+#define JSON_NONE   0x001
+#define JSON_NUMBER 0x002
+#define JSON_STR    0x004
+#define JSON_BOOL   0x008
+#define JSON_NULL   0x010
+#define JSON_ARRAY  0x020
+#define JSON_OBJECT 0x040
+
+#define JSON_TYPES  0x0FF
+#define JSON_NOCOPY 0x100
+
+#define JSONType(j) ((j->type & JSON_TYPES))
 
 typedef struct json_data JSON;
 struct json_data {
-  enum json_type type;          /* The type of JSON data represented by 'data' */
+  int type;          /* The type of JSON data represented by 'data' */
   void *data;                   /* A pointer to a char *, int * or json_data struct, depending on the value of 'type' */
   struct json_data *next;       /* Pointer to the next json_data in the linked list, for arrays/objects */
 };

--- a/src/conf.c
+++ b/src/conf.c
@@ -544,6 +544,10 @@ PENNCONF conftable[] = {
   {"sendmail_prog", cf_str, options.sendmail_prog,
    sizeof options.sendmail_prog, 0, NULL}
   ,
+  {"rest_object", cf_dbref, &options.rest_object, 100000, 0, "net"}
+  ,
+  {"rest_attr", cf_str, options.rest_attr, sizeof options.rest_attr, 0, "net"}
+  ,
 
   {NULL, NULL, NULL, 0, 0, NULL}
 };
@@ -1537,6 +1541,8 @@ conf_default_set(void)
   options.log_max_size = 100;
   strcpy(options.log_size_policy, "trim");
   strcpy(options.sendmail_prog, "sendmail");
+  options.rest_object = NOTHING;
+  strcpy(options.rest_attr, "");
 }
 
 #undef set_string_option


### PR DESCRIPTION
Allows browsers to send GET requests for /REST/something.json to poll the MUSH for information. The request is sent to an object defined in mush.cnf, which returns a response in JSON format. If the object isn't defined or returns nothing, it checks for a hardcoded handler; currently only one exists, for /REST/who.json, which returns an array of online players.

Also makes a few small improvements to the JSON code, and tweaks the existing responses for GET/POST being sent (HTTP redirect instead of \<meta\> tag, HTML5 instead of HTML4.01, etc). 

Issue #1093 