### PR TITLE
Qon extchat hidden fixes

### DIFF
--- a/CHANGES.186
+++ b/CHANGES.186
@@ -35,7 +35,7 @@ Fixes:
  * Fix a potential crash in @stats/tables [SW]
  * controls(<obj>, <victim>/<attr>) would return 1 even if <obj> didn't control <victim>. [MG]
  * Although json(object) would correctly return {}, an empty JSON object, other JSON functions would throw an error and say it was invalid. [MG]
- * Fixed channel_send() incorrectly setting speaker to NOTHING for non-spoofed chat messages when adding text to the channel buffer [Qon]
+ * Fixed channel_send() incorrectly setting speaker to NOTHING for non-spoofed chat messages when adding text to the channel buffer. PR by Qon.
 
 Minor changes:
  * PLAYER`CREATE event now passes the registered email if the player was created using 'register' at the login screen. PR by Qon.
@@ -51,10 +51,10 @@ Minor changes:
  * @chown <obj>/<attr>=<owner> acts as an alias for @atrchown, for Rhost compatability. [MG]
  * @grep/parent checks inherited attributes too. [MG,Rhost]
  * Penn now understands XTERM when reading raw ansi tags. It essentially never does this, though. Requested by spork. [975-MG]
- * Players that are See_All, Royaty or Wizard can see Hidden-connect messages on any channel. [Qon]
- * Players hidden on a channel with @chan/hide will not show connect messages to players unless they are see_all or roy/wiz. [Qon]
- * Hidden-connects/disconnects only show on @chan/recall and crecall() if you are see_all, roy or wizard, except for your own messages. [Qon]
- * DARK-connect/disconnect/etc messages are no longer announced over channels. Dark and Hidden are two different things. [Qon]
+ * Players that are See_All, Royaty or Wizard can see Hidden-connect messages on any channel. PR by Qon.
+ * Players hidden on a channel with @chan/hide will not show connect messages to players unless they are see_all or roy/wiz. PR by Qon.
+ * Hidden-connects/disconnects only show on @chan/recall and crecall() if you are see_all, roy or wizard, except for your own messages. PR by Qon.
+ * DARK-connect/disconnect/etc messages are no longer announced over channels. Dark and Hidden are two different things. PR by Qon.
  
 Functions:
  * Added setsymdiff() [SW]

--- a/CHANGES.186
+++ b/CHANGES.186
@@ -35,6 +35,7 @@ Fixes:
  * Fix a potential crash in @stats/tables [SW]
  * controls(<obj>, <victim>/<attr>) would return 1 even if <obj> didn't control <victim>. [MG]
  * Although json(object) would correctly return {}, an empty JSON object, other JSON functions would throw an error and say it was invalid. [MG]
+ * Fixed channel_send() incorrectly setting speaker to NOTHING for non-spoofed chat messages when adding text to the channel buffer [Qon]
 
 Minor changes:
  * PLAYER`CREATE event now passes the registered email if the player was created using 'register' at the login screen. PR by Qon.
@@ -50,7 +51,11 @@ Minor changes:
  * @chown <obj>/<attr>=<owner> acts as an alias for @atrchown, for Rhost compatability. [MG]
  * @grep/parent checks inherited attributes too. [MG,Rhost]
  * Penn now understands XTERM when reading raw ansi tags. It essentially never does this, though. Requested by spork. [975-MG]
-
+ * Players that are See_All, Royaty or Wizard can see Hidden-connect messages on any channel. [Qon]
+ * Players hidden on a channel with @chan/hide will not show connect messages to players unless they are see_all or roy/wiz. [Qon]
+ * Hidden-connects/disconnects only show on @chan/recall and crecall() if you are see_all, roy or wizard, except for your own messages. [Qon]
+ * DARK-connect/disconnect/etc messages are no longer announced over channels. Dark and Hidden are two different things. [Qon]
+ 
 Functions:
  * Added setsymdiff() [SW]
  * Added randextract(), a more powerful version of randword(). [MG,Rhost]

--- a/hdrs/extchat.h
+++ b/hdrs/extchat.h
@@ -87,7 +87,7 @@ struct chanuser {
 #define CB_SEEALL     0x200     /* Only see_all players can see this message */
 
 /* channel_buffer types */
-#define CBTYPE_SEEALL   0x01    /* Only see_all players can see this message
+#define CBTYPE_SEEALL   1    /* Only see_all players can see this message
                                  * using @chan/recall or crecall() */
                                  
 #define CUdbref(u) ((u)->who)
@@ -98,7 +98,6 @@ struct chanuser {
 #define Chanuser_Hide(u) ((CUtype(u) & CU_HIDE) || (IsPlayer(CUdbref(u)) && hidden(CUdbref(u))))
 #define Chanuser_Gag(u) (CUtype(u) & CU_GAG)
 #define Chanuser_Combine(u) (CUtype(u) & CU_COMBINE)
-#define Hidden(d) (d->hide == 1)
 
 /* This is a chat channel */
 #define CHAN_NAME_LEN 31

--- a/hdrs/extchat.h
+++ b/hdrs/extchat.h
@@ -84,7 +84,12 @@ struct chanuser {
 #define CB_QUIET      0x80      /* Do not prepend the <Channel> name */
 #define CB_NOCOMBINE  0x100     /* Don't send this message to players with
                                  * their channels set COMBINE */
+#define CB_SEEALL     0x200     /* Only see_all players can see this message */
 
+/* channel_buffer types */
+#define CBTYPE_SEEALL   0x01    /* Only see_all players can see this message
+                                 * using @chan/recall or crecall() */
+                                 
 #define CUdbref(u) ((u)->who)
 #define CUtype(u) ((u)->type)
 #define CUtitle(u) ((u)->title)
@@ -93,6 +98,7 @@ struct chanuser {
 #define Chanuser_Hide(u) ((CUtype(u) & CU_HIDE) || (IsPlayer(CUdbref(u)) && hidden(CUdbref(u))))
 #define Chanuser_Gag(u) (CUtype(u) & CU_GAG)
 #define Chanuser_Combine(u) (CUtype(u) & CU_COMBINE)
+#define Hidden(d) (d->hide == 1)
 
 /* This is a chat channel */
 #define CHAN_NAME_LEN 31

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -71,9 +71,6 @@
 #ifdef HAVE_POLL_H
 #include <poll.h>
 #endif
-#ifdef TREKMUSH
-#include "space.h"
-#endif
 #include "access.h"
 #include "ansi.h"
 #include "attrib.h"

--- a/src/extchat.c
+++ b/src/extchat.c
@@ -3212,7 +3212,7 @@ chat_player_announce(DESC *desc_player, char *msg, int ungag)
     up = onchannel(player, c);
     if (up) {
       if (!Channel_Quiet(c)) {
-        if (Chanuser_Hide(up) || Hidden(desc_player))
+        if (Chanuser_Hide(up) || (desc_player->hide == 1))
           channel_send(c, player,
                      CB_NOCOMBINE | CB_CHECKQUIET | CB_PRESENCE | CB_POSE | CB_SEEALL, msg);
         else
@@ -3246,7 +3246,7 @@ chat_player_announce(DESC *desc_player, char *msg, int ungag)
       bp = buff;
       bp2 = buff2;
       
-      if (Hidden(desc_player) && !See_All(viewer) && (player != viewer))
+      if ((desc_player->hide == 1) && !See_All(viewer) && (player != viewer))
         continue;
       
       for (c = channels; c; c = c->next) {


### PR DESCRIPTION
This change removes dark-connect/disconnect/reconnect messages, as well as removing Dark from being used in channel messages at all.

If you connect hidden (ch from login screen), only see_all, roy or wizard players will see your hidden-connect message on ANY channel you are on.

If you are channel hidden (via @chan/hide), only see_all, roy, or wizard players will see your connect/disconnect messages on any channel you are on. (It will -not- be prefixed with HIDDEN- though).

Same rules apply for @chan/recall and crecall().  Except you can always see your own connect/disconnect messages.

This PR finalizes the disconnection (pun intended) of DARK and HIDDEN.
