### PR TITLE
Fix for issue #1100: MySQL Commmands out of Sync

### DIFF
--- a/src/sql.c
+++ b/src/sql.c
@@ -1177,8 +1177,20 @@ penn_mysql_sql_query(const char *q_string, int *affected_rows)
 static void
 penn_mysql_free_sql_query(MYSQL_RES *qres)
 {
-  while (mysql_fetch_row(qres)) ;
+  while (mysql_fetch_row(qres));
   mysql_free_result(qres);
+  while (mysql_more_results(mysql_connp)) {
+    int affected_rows =  mysql_affected_rows(mysql_connp);
+    /*
+       We are assuming the first result is the only result we wanted. After all,
+       we do not support multi-query or multiple results.
+       As such, we're cleaning the rest up with empty strings - just so we can free
+       the remaining results from the structure.
+    */
+    qres = sql_query("", &affected_rows);
+    mysql_free_result(qres);
+    mysql_next_result(mysql_connp);
+  }
 }
 
 #endif


### PR DESCRIPTION
Do a proper cleanup to prevent commands from getting out of sync.

See Issue #1100 