### PR TITLE
Added @nuke/list (suggested by Kitai).

### DIFF
--- a/game/txt/hlp/penncmd.hlp
+++ b/game/txt/hlp/penncmd.hlp
@@ -967,9 +967,12 @@ See also: look, @adescribe, @idescribe, @descformat
 & @nuke
   @destroy[/override] <object>
   @nuke <object>
+  @nuke/list <object-list>
   @undestroy <object>
 
   The @destroy command marks <object> for destruction by setting the GOING flag on it. If <object> is a room, all the exits in the room are marked for destruction as well. If <object> is a player, and the @config option destroy_possessions is on, everything he owns is marked for destruction as well. (If really_safe is also on, his SAFE objects will not be destroyed.) If the adestroy @config option is on, the ADESTROY attribute will be triggered when the object is first @destroy'd.
+
+  The @nuke/list command marks all objects in the space-separated <object-list> for destruction in the same manner as a normal @nuke.
   
   The MUSH checks for GOING objects every ten minutes or so (see '@config purge_interval'); each one is set with the GOING_TWICE flag, and will be destroyed totally on the next cycle. You can save it from destruction during this period using the @undestroy command, or @destroy it again to destroy it instantly.
   

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1249,7 +1249,26 @@ COMMAND(cmd_newpassword)
 
 COMMAND(cmd_nuke)
 {
-  do_destroy(executor, arg_left, 1, queue_entry->pe_info);
+  char *s = arg_left;
+  char *e;
+  if (SW_ISSET(sw, SWITCH_LIST)) {
+    while (s != NULL) {
+      e = strchr(s, ' ');
+      if(e != NULL) {
+        *e = '\0';
+        do_destroy(executor, s, 1, queue_entry->pe_info);
+        *e = ' ';
+        s = e + 1;
+      }
+      else {
+        do_destroy(executor, s, 1, queue_entry->pe_info);
+        s = NULL;
+      }
+    }
+  }
+  else {
+    do_destroy(executor, arg_left, 1, queue_entry->pe_info);
+  }
 }
 
 COMMAND(cmd_oemit)

--- a/src/command.c
+++ b/src/command.c
@@ -254,7 +254,7 @@ COMLIST commands[] = {
   {"@NSZEMIT", "NOISY SILENT", cmd_zemit,
    CMD_T_ANY | CMD_T_EQSPLIT | CMD_T_NOGAGGED,
    0, 0},
-  {"@NUKE", NULL, cmd_nuke, CMD_T_ANY | CMD_T_NOGAGGED, 0, 0},
+  {"@NUKE", "LIST", cmd_nuke, CMD_T_ANY | CMD_T_NOGAGGED, 0, 0},
 
   {"@OEMIT", "NOEVAL SPOOF", cmd_oemit,
    CMD_T_ANY | CMD_T_EQSPLIT | CMD_T_NOGAGGED, 0, 0},


### PR DESCRIPTION
This is probably a horrible implementation of a silly idea. The job of selling it... now falls to Kitai!

(and, if it doesn't get in, `@dolist/inline <object-list>=@nuke %i0` still works!)