### PR TITLE
Make @mail pay attention to MAILCURF when passed a player or dbref.

### DIFF
--- a/src/extmail.c
+++ b/src/extmail.c
@@ -756,7 +756,7 @@ do_mail_list(dbref player, const char *msglist)
     return;
   }
   FA_Init(i);
-  folder = AllInFolder(ms) ? player_folder(player) : MSFolder(ms);
+  folder = (AllInFolder(ms) || ms.player != 0) ? player_folder(player) : MSFolder(ms);
   if (SUPPORT_PUEBLO)
     notify_noenter(player, open_tag("SAMP"));
   notify_format(player,


### PR DESCRIPTION
If `do_mail_list` is passed a `msglist` in `#<dbref>` or `*<player-name>` format, `ms.flags` is not set `M_FOLDER` by `parse_msglist`, so `AllInFolder(ms)` returns false and the player's `MAILCURF` goes unqueried. However, if (and only if) either of those types of `msglist` (or 'me') are passed to `parse_msglist`, `ms.player` is set to a nonzero value. Thus, if that nonzero value is detected here, folder should be set according to the player's `MAILCURF`.

Plus, this fixes the bug portion of issue #77.