### PR TITLE
Strip markup from u()'s first argument

### DIFF
--- a/CHANGES.186
+++ b/CHANGES.186
@@ -19,6 +19,7 @@ Fixes:
  * Fix overflow bug in mapsql(). [MG]
  * elements() would very rarely give an extra delimiter. Reported by Ashen-Shugar. [1108-MG]
  * Missing null termination in 'buy' fixed by CLDawes. [1128]
+ * Strip markup from u()'s first argument (obj/attrib) before attempting to find and parse it. Patch by Qon.
 
 Major changes:
  * Supports client charset negotiation of UTF-8. This means the mush

--- a/src/funufun.c
+++ b/src/funufun.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 
+#include "ansi.h"
 #include "attrib.h"
 #include "conf.h"
 #include "dbdefs.h"
@@ -217,12 +218,13 @@ FUNCTION(fun_ufun)
   int flags = UFUN_OBJECT;
   PE_REGS *pe_regs;
   int i;
-
+  char *stripped = remove_markup(args[0], NULL);
+  
   if (!strcmp(called_as, "ULAMBDA")) {
     flags |= UFUN_LAMBDA;
   }
 
-  if (!fetch_ufun_attrib(args[0], executor, &ufun, flags)) {
+  if (!fetch_ufun_attrib(stripped, executor, &ufun, flags)) {
     safe_str(T(ufun.errmess), buff, bp);
     return;
   }


### PR DESCRIPTION
Fixes an issue caused by passing ansified text to u(). 
This cropped up when using a channel mogrifier and passing a colored channel name directly to a u() call.
Maybe do the same for objeval(), etc. type functions?
