### PR TITLE
Fix V614 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/extchat.c
+++ b/src/extchat.c
@@ -2145,7 +2145,7 @@ do_channel_list(dbref player, const char *partname, int types)
   char dispname[BUFFER_LEN];
   char *dp;
   char *shortoutput = NULL, *sp;
-  int numblanks;
+  int numblanks = 0;
 
   if (!(types & CHANLIST_QUIET)) {
     if (SUPPORT_PUEBLO)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Uninitialized variable 'numblanks' used.