### PR TITLE
Disallow '=' in passwords

### DIFF
--- a/CHANGES.186
+++ b/CHANGES.186
@@ -22,6 +22,7 @@ Fixes:
  * Fix an off-by-one error in switch handling code that could cause a crash on startup. [SW]
  * Fix an issue with table() not fitting maximum number of columns in a line. Reported by Degraine. [1119-SW].
  * Fix an issue where writes to a socket sometimes shut down the connection needlessly. [1136-SW]
+ * Disallow '=' to be used in passwords. Causes problems when changing passwords later. Reported by Volund, PR by Qon.
 
 Major changes:
  * Supports client charset negotiation of UTF-8. This means the mush can send and recieve UTF-8, but still uses latin-1 internally. Unicode characters that aren't part of latin-1 are not supported. Yet. [SW]

--- a/game/txt/hlp/penncmd.hlp
+++ b/game/txt/hlp/penncmd.hlp
@@ -2075,7 +2075,8 @@ See also: @name, name(), VERBS
   The <player> argument is evaluated, but the <password> argument is not when the command is entered directly from a client.
   
   If the /generate switch is given, a new, random password is generated automatically, and shown to the enactor (but not to <player>).
-
+  The <password> must not contain whitespace, unprintable characters, or '='.
+  
 See also: @password, checkpass()
 & @notify
   @notify[/any][/all] <object>[/<attribute>][=<number>]
@@ -2170,6 +2171,7 @@ See also: PARENTS, parent(), lparent(), ANCESTORS
   @password <old password>=<new password>
 
   This changes your password. Please note that passwords ARE case-sensitive. The arguments are not evaluated.
+  The <new password> must not contain whitespace, unprintable characters, or '='.
   
 See also: @newpassword, checkpass()
 & @pageformat

--- a/src/predicat.c
+++ b/src/predicat.c
@@ -921,6 +921,8 @@ ok_password(const char *password)
     if (!(isprint(*scan) && !isspace(*scan))) {
       return 0;
     }
+    if (*scan == '=')
+      return 0;
   }
 
   return 1;


### PR DESCRIPTION
Using '=' in passwords causes problems with changing the password later using '@password', this change makes '=' an unacceptable character in passwords going forward.

Players with a '=' in the current password should be @newpassword'd by a Wizard.

As reported by Volund.