### PR TITLE
Allow HTML tag markup with either pueblo or websockets enabled  and fix the blank input error at connect

### DIFF
--- a/hdrs/conf.h
+++ b/hdrs/conf.h
@@ -422,6 +422,8 @@ int can_view_config_option(dbref player, PENNCONF *opt);
 #define START_QUOTA (options.starting_quota)
 #define LOG_WIPE_PASSWD (options.log_wipe_passwd)
 #define SUPPORT_PUEBLO (options.support_pueblo)
+#define SUPPORT_WEBSOCKETS (options.use_ws)
+#define SUPPORT_HTML (SUPPORT_PUEBLO || SUPPORT_WEBSOCKETS)
 
 #define QUEUE_QUOTA (options.player_queue_limit)
 

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -3784,7 +3784,7 @@ process_input_helper(DESC *d, char *tbuf1, int got)
        * so it's nice of us to try to handle this.
        */
       *p = '\0';
-#ifdef WITHOUT_WEBSOCKETS /* */
+#ifdef WITHOUT_WEBSOCKETS
       /* WebSockets processing is interested in empty lines. */
       if (p > d->raw_input)
 #endif /* WITHOUT_WEBSOCKETS */
@@ -3794,7 +3794,7 @@ process_input_helper(DESC *d, char *tbuf1, int got)
         q++; /* For clients that work */
     } else if (*q == '\n') {
       *p = '\0';
-#ifdef WITHOUT_WEBSOCKETS /* */
+#ifdef WITHOUT_WEBSOCKETS
       /* WebSockets processing is interested in empty lines. */
       if (p > d->raw_input)
 #endif /* WITHOUT_WEBSOCKETS */
@@ -4271,6 +4271,7 @@ check_connect(DESC *d, const char *msg)
 
   parse_connect(msg, command, user, password);
   
+  /* fail quietly if command is an empty string */
   if (strlen(command) < 1) return 1;
 
   if (!check_fails(d->ip)) {

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -3784,7 +3784,7 @@ process_input_helper(DESC *d, char *tbuf1, int got)
        * so it's nice of us to try to handle this.
        */
       *p = '\0';
-#ifdef WITHOUT_WEBSOCKETS
+#ifdef WITHOUT_WEBSOCKETS /* */
       /* WebSockets processing is interested in empty lines. */
       if (p > d->raw_input)
 #endif /* WITHOUT_WEBSOCKETS */
@@ -3794,7 +3794,7 @@ process_input_helper(DESC *d, char *tbuf1, int got)
         q++; /* For clients that work */
     } else if (*q == '\n') {
       *p = '\0';
-#ifdef WITHOUT_WEBSOCKETS
+#ifdef WITHOUT_WEBSOCKETS /* */
       /* WebSockets processing is interested in empty lines. */
       if (p > d->raw_input)
 #endif /* WITHOUT_WEBSOCKETS */
@@ -4270,6 +4270,8 @@ check_connect(DESC *d, const char *msg)
   dbref player;
 
   parse_connect(msg, command, user, password);
+  
+  if (strlen(command) < 1) return 1;
 
   if (!check_fails(d->ip)) {
     queue_string_eol(d, T(connect_fail_limit_exceeded));

--- a/src/extchat.c
+++ b/src/extchat.c
@@ -2175,7 +2175,7 @@ do_channel_list(dbref player, const char *partname, int types)
       safe_str(ChanName(c), shortoutput, &sp);
       continue;
     }
-    if (SUPPORT_PUEBLO)
+    if (SUPPORT_HTML)
       snprintf(numusers, BUFFER_LEN, "%c%cA XCH_CMD=\"@channel/who %s\" "
                                      "XCH_HINT=\"See who's on this channel "
                                      "now\"%c%5d%c%c/A%c",

--- a/src/extmail.c
+++ b/src/extmail.c
@@ -765,7 +765,7 @@ do_mail_list(dbref player, const char *msglist)
       i[Folder(mp)]++;
       if (mail_match(player, mp, ms, i[Folder(mp)])) {
         /* list it */
-        if (SUPPORT_PUEBLO)
+        if (SUPPORT_HTML)
           notify_noenter(player,
                          tprintf("%c%cA XCH_CMD=\"@mail/read %d:%d\" "
                                  "XCH_HINT=\"Read message %d in folder %d\"%c",
@@ -783,7 +783,7 @@ do_mail_list(dbref player, const char *msglist)
                          : ' '),
                       sender, 30, subj,
                       mail_list_time(show_time(mp->time, 0), 1));
-        if (SUPPORT_PUEBLO)
+        if (SUPPORT_HTML)
           notify_noenter(player,
                          tprintf("%c%c/A%c", TAG_START, MARKUP_HTML, TAG_END));
       }
@@ -968,7 +968,7 @@ do_mail_reviewlist(dbref player, dbref target)
     if (mail_match(player, mp, ms, i)) {
       /* list it */
       i++;
-      if (SUPPORT_PUEBLO)
+      if (SUPPORT_HTML)
         notify_noenter(player,
                        tprintf("%c%cA XCH_CMD=\"@mail/review %s=%d\" "
                                "XCH_HINT=\"Read message %d sent to %s\"%c",
@@ -991,7 +991,7 @@ do_mail_reviewlist(dbref player, dbref target)
                           ? '*'
                           : ' '),
                     nbuff, 30, subj, mail_list_time(show_time(mp->time, 0), 1));
-      if (SUPPORT_PUEBLO)
+      if (SUPPORT_HTML)
         notify_noenter(player,
                        tprintf("%c%c/A%c", TAG_START, MARKUP_HTML, TAG_END));
     }

--- a/src/look.c
+++ b/src/look.c
@@ -163,7 +163,8 @@ look_exits(dbref player, dbref loc, const char *exit_name, NEW_PE_INFO *pe_info)
     mush_free(nbuf, "string");
     return;
   }
-
+  
+  
   PUSE;
   tag_wrap("FONT", "SIZE=+1", exit_name);
   PEND;
@@ -180,7 +181,7 @@ look_exits(dbref player, dbref loc, const char *exit_name, NEW_PE_INFO *pe_info)
                     &p, NOTHING);
       *p = '\0';
       if (Transparented(loc) && !(Opaque(thing))) {
-        if (SUPPORT_PUEBLO && !texits) {
+        if (SUPPORT_HTML && !texits) {
           texits = 1;
           notify_noenter_by(loc, player, open_tag("UL"));
         }
@@ -215,7 +216,7 @@ look_exits(dbref player, dbref loc, const char *exit_name, NEW_PE_INFO *pe_info)
       }
     }
   }
-  if (SUPPORT_PUEBLO && texits) {
+  if (SUPPORT_HTML && texits) {
     PUSE;
     tag_cancel("UL");
     PEND;
@@ -484,16 +485,18 @@ look_room(dbref player, dbref loc, int key, NEW_PE_INFO *pe_info)
   /* don't give the unparse if looking through Transparent exit */
   if (!look_through_exit) {
     PUSE;
-    tag("XCH_PAGE CLEAR=\"LINKS PLUGINS\"");
-    if (SUPPORT_PUEBLO && (key & LOOK_AUTO)) {
-      a = atr_get(loc, "VRML_URL");
-      if (a) {
-        tag(tprintf("IMG XCH_GRAPH=LOAD HREF=\"%s\"", atr_value(a)));
-      } else {
-        tag("IMG XCH_GRAPH=HIDE");
+    if (SUPPORT_PUEBLO) {
+      tag("XCH_PAGE CLEAR=\"LINKS PLUGINS\"");
+      if (key & LOOK_AUTO) {
+        a = atr_get(loc, "VRML_URL");
+        if (a) {
+          tag(tprintf("IMG XCH_GRAPH=LOAD HREF=\"%s\"", atr_value(a)));
+        } else {
+          tag("IMG XCH_GRAPH=HIDE");
+        }
       }
+      tag("HR");
     }
-    tag("HR");
     tag_wrap("FONT", "SIZE=+2", unparse_room(player, loc, pe_info));
     PEND;
     notify_by(loc, player, pbuff);

--- a/src/look.c
+++ b/src/look.c
@@ -164,7 +164,6 @@ look_exits(dbref player, dbref loc, const char *exit_name, NEW_PE_INFO *pe_info)
     return;
   }
   
-  
   PUSE;
   tag_wrap("FONT", "SIZE=+1", exit_name);
   PEND;

--- a/src/markup.c
+++ b/src/markup.c
@@ -2955,7 +2955,7 @@ safe_markup(char const *a_tag, char *buf, char **bp, char type)
 int
 safe_tag(char const *a_tag, char *buff, char **bp)
 {
-  if (SUPPORT_PUEBLO)
+  if (SUPPORT_HTML)
     return safe_markup(a_tag, buff, bp, MARKUP_HTML);
   return 0;
 }
@@ -2990,7 +2990,7 @@ safe_markup_cancel(char const *a_tag, char *buf, char **bp, char type)
 int
 safe_tag_cancel(char const *a_tag, char *buf, char **bp)
 {
-  if (SUPPORT_PUEBLO)
+  if (SUPPORT_HTML)
     return safe_markup_cancel(a_tag, buf, bp, MARKUP_HTML);
   return 0;
 }
@@ -3012,7 +3012,7 @@ safe_tag_wrap(char const *a_tag, char const *params, char const *data,
 {
   int result = 0;
   char *save = *bp;
-  if (SUPPORT_PUEBLO) {
+  if (SUPPORT_HTML) {
     safe_chr(TAG_START, buf, bp);
     safe_chr(MARKUP_HTML, buf, bp);
     safe_str(a_tag, buf, bp);
@@ -3023,7 +3023,7 @@ safe_tag_wrap(char const *a_tag, char const *params, char const *data,
     safe_chr(TAG_END, buf, bp);
   }
   result = safe_str(data, buf, bp);
-  if (SUPPORT_PUEBLO) {
+  if (SUPPORT_HTML) {
     result = safe_tag_cancel(a_tag, buf, bp);
   }
   /* If it didn't all fit, rewind. */

--- a/src/unparse.c
+++ b/src/unparse.c
@@ -146,7 +146,7 @@ real_unparse(dbref player, dbref loc, int obey_myopic, int use_nameformat,
   else
     p = buf;
 
-  if (SUPPORT_PUEBLO) {
+  if (SUPPORT_HTML) {
     PUSE;
     tag_wrap("A", tprintf("XCH_CMD=\"examine #%d\"", loc), p);
     PEND;


### PR DESCRIPTION
This pull request adds a SUPPORT_WEBSOCKETS macro for the use_ws config option, similar to the SUPPORT_PUEBLO macro. It also adds a macro SUPPORT_HTML which is either (SUPPORT_PUEBLO || SUPPORT_WEBSOCKETS). SUPPORT_HTML is used in several places instead of SUPPORT_PUEBLO to allow HTML tags to be marked up if either Websockets or Pueblo are enabled. This enables HTML markup for Websockets, without having to turn on Pueblo for all clients.

There is also a fix to the error messages on blank input at the connect screen problem that @talvo  noticed, and that is responsible for noticing the error referenced in #1151 . This fix simply returns quietly if the command is an empty string, before proceeding with the connect command in bsd.c:check_connect().

Cheers,
-grapenut