### PR TITLE
changed SSL_VERIFY_PEER to SSL_VERIFY_NONE whenever client certificat…

### DIFF
--- a/src/myssl.c
+++ b/src/myssl.c
@@ -175,7 +175,7 @@ ssl_init(char *private_key_file, char *ca_file, char *ca_dir,
                            SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
                            client_verify_callback);
       else
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, client_verify_callback);
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, client_verify_callback);
 #if (OPENSSL_VERSION_NUMBER < 0x0090600fL)
       SSL_CTX_set_verify_depth(ctx, 1);
 #endif


### PR DESCRIPTION
A fix for issue #1155 . Changes SSL_VERIFY_PEER to SSL_VERIFY_NONE whenever the config option `ssl_require_client_cert` is turned off. This prevents the server from requesting client certificates that is doesn't intend to verify.