### PR TITLE
Remove <FONT> tags from player and object names

### DIFF
--- a/hdrs/pueblo.h
+++ b/hdrs/pueblo.h
@@ -20,8 +20,6 @@
 #define PUSE pp = pbuff
 #define PEND *pp = 0;
 
-#define pueblo_tag_wrap(a, b, c) if (SUPPORT_PUEBLO) { safe_tag_wrap(a, b, c, pbuff, &pp, NOTHING); } \
-                                 else { safe_str(c, pbuff, &pp); }
 #define tag_wrap(a, b, c) safe_tag_wrap(a, b, c, pbuff, &pp, NOTHING)
 #define tag(a) safe_tag(a, pbuff, &pp)
 #define tag_cancel(a) safe_tag_cancel(a, pbuff, &pp)

--- a/hdrs/pueblo.h
+++ b/hdrs/pueblo.h
@@ -20,6 +20,8 @@
 #define PUSE pp = pbuff
 #define PEND *pp = 0;
 
+#define pueblo_tag_wrap(a, b, c) if (SUPPORT_PUEBLO) { safe_tag_wrap(a, b, c, pbuff, &pp, NOTHING); } \
+                                 else { safe_str(c, pbuff, &pp); }
 #define tag_wrap(a, b, c) safe_tag_wrap(a, b, c, pbuff, &pp, NOTHING)
 #define tag(a) safe_tag(a, pbuff, &pp)
 #define tag_cancel(a) safe_tag_cancel(a, pbuff, &pp)

--- a/src/look.c
+++ b/src/look.c
@@ -164,7 +164,7 @@ look_exits(dbref player, dbref loc, const char *exit_name, NEW_PE_INFO *pe_info)
   }
 
   PUSE;
-  tag_wrap("FONT", "SIZE=+1", exit_name);
+  pueblo_tag_wrap("FONT", "SIZE=+1", exit_name);
   PEND;
   notify_by(loc, player, pbuff);
 
@@ -294,7 +294,7 @@ look_contents(dbref player, dbref loc, const char *contents_name,
     if (can_see(player, thing, can_see_loc)) {
       /* something exists!  show him everything */
       PUSE;
-      tag_wrap("FONT", "SIZE=+1", contents_name);
+      pueblo_tag_wrap("FONT", "SIZE=+1", contents_name);
       tag("UL");
       PEND;
       notify_nopenter_by(loc, player, pbuff);
@@ -442,7 +442,7 @@ look_simple(dbref player, dbref thing, int key, NEW_PE_INFO *pe_info)
   PUEBLOBUFF;
 
   PUSE;
-  tag_wrap("FONT", "SIZE=+2", unparse_object_myopic(player, thing, AN_LOOK));
+  pueblo_tag_wrap("FONT", "SIZE=+2", unparse_object_myopic(player, thing, AN_LOOK));
   PEND;
   notify_by(thing, player, pbuff);
   look_description(player, thing, T("You see nothing special."), "DESCRIBE",
@@ -506,7 +506,7 @@ look_room(dbref player, dbref loc, int key, NEW_PE_INFO *pe_info)
       }
       tag("HR");
     }
-    tag_wrap("FONT", "SIZE=+2", unparse_room(player, loc, pe_info));
+    pueblo_tag_wrap("FONT", "SIZE=+2", unparse_room(player, loc, pe_info));
     PEND;
     notify_by(loc, player, pbuff);
   }
@@ -845,7 +845,7 @@ do_examine(dbref player, const char *xname, enum exam_type flag, int all,
   }
   if (ok) {
     PUSE;
-    tag_wrap("FONT", "SIZE=+2", object_header(player, thing));
+    pueblo_tag_wrap("FONT", "SIZE=+2", object_header(player, thing));
     PEND;
     notify(player, pbuff);
     if (FLAGS_ON_EXAMINE)

--- a/src/look.c
+++ b/src/look.c
@@ -164,7 +164,7 @@ look_exits(dbref player, dbref loc, const char *exit_name, NEW_PE_INFO *pe_info)
   }
 
   PUSE;
-  pueblo_tag_wrap("FONT", "SIZE=+1", exit_name);
+  safe_str(exit_name, pbuff, &pp);
   PEND;
   notify_by(loc, player, pbuff);
 
@@ -294,7 +294,7 @@ look_contents(dbref player, dbref loc, const char *contents_name,
     if (can_see(player, thing, can_see_loc)) {
       /* something exists!  show him everything */
       PUSE;
-      pueblo_tag_wrap("FONT", "SIZE=+1", contents_name);
+      safe_str(contents_name, pbuff, &pp);
       tag("UL");
       PEND;
       notify_nopenter_by(loc, player, pbuff);
@@ -442,7 +442,7 @@ look_simple(dbref player, dbref thing, int key, NEW_PE_INFO *pe_info)
   PUEBLOBUFF;
 
   PUSE;
-  pueblo_tag_wrap("FONT", "SIZE=+2", unparse_object_myopic(player, thing, AN_LOOK));
+  safe_str(unparse_object_myopic(player, thing, AN_LOOK), pbuff, &pp);
   PEND;
   notify_by(thing, player, pbuff);
   look_description(player, thing, T("You see nothing special."), "DESCRIBE",
@@ -506,7 +506,7 @@ look_room(dbref player, dbref loc, int key, NEW_PE_INFO *pe_info)
       }
       tag("HR");
     }
-    pueblo_tag_wrap("FONT", "SIZE=+2", unparse_room(player, loc, pe_info));
+    safe_str(unparse_room(player, loc, pe_info), pbuff, &pp);
     PEND;
     notify_by(loc, player, pbuff);
   }
@@ -845,7 +845,7 @@ do_examine(dbref player, const char *xname, enum exam_type flag, int all,
   }
   if (ok) {
     PUSE;
-    pueblo_tag_wrap("FONT", "SIZE=+2", object_header(player, thing));
+    safe_str(object_header(player, thing), pbuff, &pp);
     PEND;
     notify(player, pbuff);
     if (FLAGS_ON_EXAMINE)


### PR DESCRIPTION
Remove <FONT> tags from player and object names, unless explicit pueblo support is enabled. This prevents them from showing up on websockets when Pueblo is disabled, which is the default configuration.