### PR TITLE
Update version requirement for libcurl to 7.43.0

### DIFF
--- a/configure
+++ b/configure
@@ -7282,7 +7282,7 @@ else
 
 fi
 
-      if test x"7.28.0" != x; then :
+      if test x"7.43.0" != x; then :
 
 		if test x"'s/^libcurl\ \+//'" != x; then :
 
@@ -7294,8 +7294,8 @@ else
 
 fi
 
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for curl ($curl_version) >= 7.28.0" >&5
-$as_echo_n "checking for curl ($curl_version) >= 7.28.0... " >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for curl ($curl_version) >= 7.43.0" >&5
+$as_echo_n "checking for curl ($curl_version) >= 7.43.0... " >&6; }
 
 
 
@@ -7315,7 +7315,7 @@ $as_echo_n "checking for curl ($curl_version) >= 7.28.0... " >&6; }
                      -e 's/[^0-9]//g'`
 
 
-  ax_compare_version_B=`echo "7.28.0" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
+  ax_compare_version_B=`echo "7.43.0" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
                      -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
                      -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
                      -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \

--- a/configure.in
+++ b/configure.in
@@ -209,7 +209,7 @@ AX_LIB_SOCKET_NSL
 AC_CHECK_LIB(event_core, event_base_loop)
 AC_CHECK_LIB(event_extra, evdns_base_new)
 AC_CHECK_LIB(event_openssl, bufferevent_openssl_socket_new)
-AX_LIB_CURL([7.28.0], [AC_DEFINE(HAVE_LIBCURL)],)
+AX_LIB_CURL([7.43.0], [AC_DEFINE(HAVE_LIBCURL)],)
 AC_CHECK_HEADERS[(curl/curl.h])
 
 # Include Winsock2 library in MinGW and MSYS builds, but not Cygwin


### PR DESCRIPTION
Updates the version requirement for libcurl to 7.43.0 required for the CURLPIPE_MULTIPLEX and CURLPIPE_HTTP1 options. See also #1198 and #1199.