### PR TITLE
Out-of-band updates for websocket clients

### DIFF
--- a/hdrs/websock.h
+++ b/hdrs/websock.h
@@ -18,6 +18,8 @@
 
 /* notify.c */
 int queue_newwrite_channel(DESC *d, const char *b, int n, char ch);
+int queue_newwrite(DESC *d, const char *b, int n);
+int process_output(DESC *d);
 
 /* websock.c */
 int is_websocket(const char *command);
@@ -27,6 +29,7 @@ void to_websocket_frame(const char **bp, int *np, char channel);
 
 int markup_websocket(char *buff, char **bp, char *data, int datalen, char *alt,
                      int altlen, char channel);
+void send_websocket_object(DESC *d, JSON *data);
 
 FUNCTION_PROTO(fun_websocket_json);
 FUNCTION_PROTO(fun_websocket_html);

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -3020,10 +3020,16 @@ FUNCTION(fun_oob)
   }
 
   DESC_ITER_CONN (d) {
-    if (d->player != who || !(d->conn_flags & CONN_GMCP))
+    if (d->player != who)
       continue;
-    send_oob(d, args[1], json);
-    i++;
+    if (d->conn_flags & CONN_WEBSOCKETS) {
+      send_websocket_object(d, json);
+      i++;
+    }
+    if (d->conn_flags & CONN_GMCP) {
+      send_oob(d, args[1], json);
+      i++;
+    }
   }
   safe_integer(i, buff, bp);
   json_free(json);

--- a/src/websock.c
+++ b/src/websock.c
@@ -19,6 +19,7 @@
 #include "confmagic.h"
 #include "strutil.h"
 #include "notify.h"
+#include "mymalloc.h"
 
 #ifndef WITHOUT_WEBSOCKETS
 #include "websock.h"
@@ -165,6 +166,7 @@ complete_handshake(DESC *d)
    * response back from the server before switching, so we're probably OK.
    */
   d->conn_flags &= ~CONN_WEBSOCKETS_REQUEST;
+  d->conn_flags &= ~CONN_PROMPT_NEWLINES;
   d->conn_flags |= CONN_WEBSOCKETS | CONN_UTF8;
 
   d->checksum[0] = 4;
@@ -576,6 +578,31 @@ markup_websocket(char *buff, char **bp, char *data, int datalen, char *alt,
   }
 
   return 0;
+}
+
+void
+send_websocket_object(DESC *d, JSON *data)
+{
+  char buff[BUFFER_LEN];
+  char *bp = buff;
+  int error = 0;
+  
+  if (!d || !(d->conn_flags & CONN_WEBSOCKETS) || !data)
+    return;
+  
+  if (data->type == JSON_OBJECT) {
+    char *str = json_to_string(data, 0);
+    error = markup_websocket(buff, &bp, str, strlen(str), NULL, 0, WEBSOCKET_CHANNEL_JSON);
+    *bp = '\0';
+    if (str)
+      mush_free(str, "json_str");
+  }
+  
+  if (!error) {
+    queue_newwrite(d, buff, strlen(buff));
+    process_output(d);
+    return;
+  }
 }
 
 static void


### PR DESCRIPTION
This PR includes the following 3 changes.

- Added the `send_websocket_object(DESC *d, JSON *data)` function in websock.c that can be used as an interface to send a JSON object directly to a descriptor. Can be used in a function like OOB() that bypasses the need for @pemit and wsjson() when only sending out-of-band JSON. It is necessary because @pemit will send unwanted blank newlines along with the embedded JSON.

- Updated the OOB() function to also send JSON to websocket clients. You can send the same payload to both GMCP and websocket clients allowing you to communicate with both types of clients using the same JSON API. While I think it fits perfectly to be able to send the same exact JSON payload out-of-band to either kind of client, it could also be packaged into its own websocket-only function.

- Removed the CONN_PROMPT_NEWLINES bit by default after the websocket handshake. Should have been done already since prompts are sent on their own channel and newlines are not needed.

Cheers,
-grapenut