### PR TITLE
Update oob() to also send the GMCP headers to websockets

### DIFF
--- a/hdrs/websock.h
+++ b/hdrs/websock.h
@@ -29,7 +29,7 @@ void to_websocket_frame(const char **bp, int *np, char channel);
 
 int markup_websocket(char *buff, char **bp, char *data, int datalen, char *alt,
                      int altlen, char channel);
-void send_websocket_object(DESC *d, cJSON *data);
+void send_websocket_object(DESC *d, const char *header, cJSON *data);
 
 FUNCTION_PROTO(fun_websocket_json);
 FUNCTION_PROTO(fun_websocket_html);

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -3015,7 +3015,7 @@ FUNCTION(fun_oob)
     if (d->player != who)
       continue;
     if (d->conn_flags & CONN_WEBSOCKETS) {
-      send_websocket_object(d, json);
+      send_websocket_object(d, args[1], json);
       i++;
     }
     if (d->conn_flags & CONN_GMCP) {


### PR DESCRIPTION
This is a continuation of my last PR with websocket OOB updates. Using the new cJSON utilities we add the GMCP header string to the data object. If the data is not an object we create a temporary object and add a reference to the data, using the header string as the key or "data" if it is not provided. I make sure to delete the temporary object if it was needed.

This should allow websocket clients to read and respond to any GMCP payload. Examples of the repackaged payload received by a websocket client:
```
th oob(%#,,null) -> {}
th oob(%#,,json(string,blah)) -> {"data":"blah"}
th oob(%#,header,null) -> {"gmcp":"header"}
th oob(%#,header,json(string,blah)) -> {"gmcp":"header", "header":"blah"}
th oob(%#,header,json(object,key,0)) -> {"gmcp":"header", "key":0}
```
