### PR TITLE
Millisecond timing in bsd.c

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -25,6 +25,11 @@ Major Changes
 
 * Built-in HTTP server support, see "help http" [GM]
 
+Minor Changes
+-------------
+
+* Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
+
 Softcode
 --------
 
@@ -33,5 +38,3 @@ Softcode
 * `formdecode()` for decoding HTTP paths and POST bodies. [GM]
 * `@respond` for manipulating HTTP response codes and headers. [GM]
 * `hmac()` for creating authentication fingerprints. [SW]
-
-

--- a/game/txt/hlp/pennv188.hlp
+++ b/game/txt/hlp/pennv188.hlp
@@ -18,6 +18,10 @@ Major Changes:
 
 * Built-in HTTP server support, see “help http” [GM]
 
+Minor Changes:
+
+* Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
+
 Softcode:
 
 * [1maddrlog()[0m for searching through list of unique IP addresses that have connected to a game. [SW]

--- a/hdrs/conf.h
+++ b/hdrs/conf.h
@@ -89,9 +89,19 @@
  */
 #define SPILLOVER_THRESHOLD 0
 /* #define SPILLOVER_THRESHOLD  (MAX_OUTPUT / 2) */
-#define COMMAND_TIME_MSEC 1000 /* time slice length in milliseconds */
-#define COMMAND_BURST_SIZE 100 /* commands allowed per user in a burst */
-#define COMMANDS_PER_TIME 1    /* commands per time slice after burst */
+
+/* Descriptor Command Quotas:
+ *
+ * Descriptors can have up to COMMAND_BURST_SIZE commands in an immediate
+ * burst, but after that goes down, it replenishes at COMMANDS_PER_SECOND per
+ * second.
+ *
+ * e.g: After pasting a file that contains 120 lines, the first 100 take 1 second,
+ * then the next 20 lines are run once each second. But 50 seconds after it's
+ * finished, the quota is back up to 50.
+ */
+#define COMMAND_BURST_SIZE    100 /* commands allowed per user in a burst */
+#define COMMANDS_PER_SECOND   1  /* commands per second, prorated by ms. */
 
 /* From conf.c */
 bool config_file_startup(const char *conf, int restrictions);

--- a/hdrs/externs.h
+++ b/hdrs/externs.h
@@ -440,6 +440,13 @@ const char *accented_name(dbref thing);
 
 /* From utils.c */
 void parse_attrib(dbref player, char *str, dbref *thing, ATTR **attrib);
+uint64_t now_msecs(); /* current milliseconds */
+#define SECS_TO_MSECS(x) (x * 1000UL)
+#ifdef WIN32
+void penn_gettimeofday(struct timeval *now); /* For platform agnosticism */
+#else
+#define penn_gettimeofday(now) gettimeofday((now), (struct timezone *) NULL)
+#endif
 
 /** Information about an attribute to ufun.
  * Prepared via fetch_ufun_attrib, used in call_ufun

--- a/hdrs/game.h
+++ b/hdrs/game.h
@@ -251,13 +251,12 @@ extern void do_destroy(dbref player, char *name, int confirm,
 void init_timer(void);
 void signal_cpu_limit(int signo);
 
-struct squeue *sq_register(time_t w, sq_func f, void *d, const char *ev);
 struct squeue *sq_register_in(int n, sq_func f, void *d, const char *ev);
 void sq_register_loop(int n, sq_func f, void *d, const char *ev);
 void sq_cancel(struct squeue *sq);
 bool sq_run_one(void);
 bool sq_run_all(void);
-int sq_secs_till_next(void);
+uint64_t sq_msecs_till_next(void);
 
 void init_sys_events(void);
 

--- a/hdrs/mushtype.h
+++ b/hdrs/mushtype.h
@@ -285,7 +285,7 @@ typedef bool (*sq_func)(void *);
 struct squeue {
   sq_func fun;         /** Function to run */
   void *data;          /** Data to pass to function, or NULL */
-  time_t when;         /** When to run the function */
+  uint64_t when;       /** When to run the function, in milliseconds. */
   char *event;         /** Softcode Event name to trigger, or NULL if none */
   struct squeue *next; /** Pointer to next squeue event in linked list */
 };
@@ -335,7 +335,7 @@ struct descriptor_data {
   char *raw_input_at;       /**< Pointer to position in raw input */
   time_t connected_at;      /**< Time of connection */
   time_t last_time;         /**< Time of last activity */
-  int quota;                /**< Quota of commands allowed */
+  uint32_t quota;           /**< Quota of commands allowed, *1000 (for milliseconds) */
   int cmds;                 /**< Number of commands sent */
   int hide;                 /**< Hide status */
   uint32_t conn_flags;      /**< Flags of connection (telnet status, etc.) */

--- a/src/cque.c
+++ b/src/cque.c
@@ -1019,7 +1019,14 @@ update_queue_load()
 void
 queue_update(void)
 {
+  static time_t last_mudtime = 0;
   MQUE *trail = NULL, *point, *next;
+
+  if (mudtime == last_mudtime) {
+    /* Only run once per second at most. */
+    return;
+  }
+  last_mudtime = mudtime;
 
   /* move contents of low priority queue onto end of normal one
    * this helps to keep objects from getting out of control since


### PR DESCRIPTION
* Millisecond timing in bsd.c for poll() and family.
* Descriptor quota fixes and improvements
* Adjust timer.c to use milliseconds.
* Fixed msec_diff to actually return millisecond count.
* Rearranging do_second(), every_second(), etc from cque and timer since they're not run every second.
* Fixing queue_load_record to be aware it probably won't run every second.
* Cleanup of timeval, slice timeout, and related math in bsd.c
* Moved error and signal result checking in bsd.c into its own function for cleaner shovechars()
* moved gettimeofday into utils.c and made generally available as penn_gettimeofday()
* Add now_msecs(), only used by timer.c now but will be used by @wait/etc.