### PR TITLE
Single queue, and massive bsd.c rewrite

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -25,6 +25,7 @@ Major Changes
 
 * Built-in HTTP server support, see "help http" [GM]
 * A single command queue for players and objects. No more @trigger waits. [GM]
+* A restructuring of bsd.c, to make it easier to reason about Penn's queue cycle. [GM]
 
 Minor Changes
 -------------

--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -26,7 +26,7 @@ As an example, this used to be a common way to ensure something was executed onc
 
 > &everysecond object=do some ; updates ; @trigger me/everysecond
 
-This will now happen, up to several thousand times per second! Add in an @wait 1, and it'll work as expected!
+This will now happen up to several thousand times per second! Add in an @wait 1, and it'll work as expected!
 
 Major Changes
 -------------

--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -24,6 +24,7 @@ Major Changes
 -------------
 
 * Built-in HTTP server support, see "help http" [GM]
+* A single command queue for players and objects. No more @trigger waits. [GM]
 
 Minor Changes
 -------------
@@ -42,4 +43,5 @@ Softcode
 Fixes
 -----
 
-* add_function in .cnf files was not properly using the upper case'd string. [#1223, MT]
+* `add_function` in .cnf files was not properly using the upper case'd string. [#1223, MT]
+* Various PCRE calls in the softcode have had CPU time limit watchdogs added. Discovered by Ashen-Shugar. [GM]

--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -20,17 +20,26 @@ Numbers next to the developer credit refer to Github issue numbers.
 Version 1.8.8 patchlevel 0 ??? ?? 2018
 ======================================
 
+WARNING! With the removal of the object queue, please be careful when upgrading that you do not have any infinitely looping triggers without an @wait.
+
+As an example, this used to be a common way to ensure something was executed once per second:
+
+> &everysecond object=do some ; updates ; @trigger me/everysecond
+
+This will now happen, up to several thousand times per second! Add in an @wait 1, and it'll work as expected!
+
 Major Changes
 -------------
 
 * Built-in HTTP server support, see "help http" [GM]
 * A single command queue for players and objects. No more @trigger waits. [GM]
 * A restructuring of bsd.c, to make it easier to reason about Penn's queue cycle. [GM]
+* Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
 
 Minor Changes
 -------------
 
-* Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
+* Sockets commands now inline $-commands, so, e.g: $,* *: chat aliases don't hit queue. [GM]
 
 Softcode
 --------

--- a/game/mushcnf.dst
+++ b/game/mushcnf.dst
@@ -347,9 +347,6 @@ player_queue_limit 100
 # the number of commands run from the queue when there is no net activity
 queue_chunk 3
 
-# the number of commands run from the queue when there is net activity
-active_queue_chunk 1
-
 # the maximum level of recursion allowed in functions
 function_recursion_limit 50
 

--- a/game/txt/hlp/penncmd.hlp
+++ b/game/txt/hlp/penncmd.hlp
@@ -520,7 +520,7 @@ See also: QUIT, LOGOUT
   @break[/queued] <boolean>[=<action list>]
   @assert[/queued] <boolean>[=<action list>]
 
-  @break stops the execution of further commands in the current action list if <boolean> is a true value. It doesn't affect new queue entries made by previous commands in the action list. It can be useful for doing error checking without having to nest @switches and suffer from delayed execution because of queueing.
+  @break stops the execution of further commands in the current action list if <boolean> is a true value. It doesn't affect new queue entries made by previous commands in the action list. It can be useful for doing error checking without having to nest @switches.
   
   If <action list> is given, it is executed instead of the rest of the commands in the current action list. By default, <action list> is run immediately, replacing the rest of the action list @break was called in. If the /queued switch is given, <action list> will instead be queued to be run later. @break also accepts an /inline switch, for Rhost compatability; this switch does nothing on PennMUSH.
 
@@ -2358,7 +2358,7 @@ See also: @inprefix, AUDIBLE, @listen
   @ps[/<switch>] [<player>]
   @ps[/debug] <pid>
   
-  @ps lists all commands currently on your 'to be executed' queue, thus allowing you to identify infinite (or unnecessary) loops with-out putting in says or poses. It gives a count of the total commands in each of the queues (Player, Object, Wait, and Semaphore), displayed in the format:
+  @ps lists all commands currently on your 'to be executed' queue, thus allowing you to identify infinite (or unnecessary) loops with-out putting in says or poses. It gives a count of the total commands in each of the queues (Command, Wait, and Semaphore), displayed in the format:
       <Number of your queued commands> / <Total number of queued commands>.
 
   Some of the queues also include a [Ndel] after the total. That number is the number of entries made by objects that have been halted but haven't been removed from the queue yet.

--- a/game/txt/hlp/pennconf.hlp
+++ b/game/txt/hlp/pennconf.hlp
@@ -145,13 +145,12 @@ Continued in help @config limits2
   max_depth=<number>: How deep indirect @lock chains can go.
   player_queue_limit=<number>: The number of commands a player can have queued at once.
   queue_loss=<number>: One in <number> times, queuing a command will cost an extra penny that doesn't get refunded.
-  queue_chunk=<number>: How many queued commands get executed in a row when there's no network activity pending.
+  queue_chunk=<number>: How many queued commands get executed in a row before checking for network activity.
 
 Continued in help @config limits3
 & @config limits3
  Limits and constants, continued.
 
-  active_queue_chunk=<number>: How many queued commands get executed in a row when there is network activity pending.
   function_recursion_limit=<number>: The depth to which softcode functions can call more functions.
   function_invocation_limit=<number>: The maximum number of softcode functions that can be called in one command.
   guest_paycheck=<number>: How many pennies guests get each day.

--- a/game/txt/hlp/penntop.hlp
+++ b/game/txt/hlp/penntop.hlp
@@ -963,25 +963,25 @@ See also: PUPPET, @force, DBREF
 & QUEUE
   QUEUE
 
-  The queue is the waiting line for action lists to be executed by the MUSH. Each time you enter an action list, it goes into the queue and stays there until its turn comes up, at which time the MUSH processes the commands and you see the results. The MUSH can execute several commands every second, so normally you see results right away.
+  The queue is the waiting line for action lists to be executed by the MUSH.  Each time you enter an action list, it goes into the queue and stays there until its turn comes up, at which time the MUSH processes the commands and you see the results. The MUSH can execute thousands of commands every second, so normally you see results right away.
 
-  However, if there are too many action lists in the queue, there may be a slight delay, called lag. The more common cause of lag, however, is network delays between you and the MUSH. Action lists that were queued by another command (like @switch, @force, @wait, etc.) also have a small delay before they run.
+  There are actually two distinct queues:
+  * Incoming socket commands. These are run immediately, so a "look" or "@ps" will happen before any other softcode that is waiting to run. A socket may 'burst' up to 100 commands, then 1 per second after that.
+  * Command queue. These enter the queue via @trigger, @force, or many other ways.
   
-Continued in 'help queue2'.
-& QUEUE2
-  There are actually several different queues in PennMUSH. Commands which are queued as a direct result of something done by a player go onto the Player queue (also called the Priority queue). Commands which are queued by other types of objects go on the lower priority Object Queue. This gives actions caused directly by a player a higher priority, to make the MUSH seem more responsive. Commands on the Object queue get moved to the Player queue after a 1 second delay.
-  
-  There is also a Wait queue, where commands queued via the @wait command go, and a Semaphore queue, where semaphore @waits go. These commands are moved to the Player or Object queue at the appropriate time, either when the @wait time elapses, or when the semaphore is @notified.
+  There is also a Wait queue, where commands queued via the @wait command go, and a Semaphore queue, where semaphore @waits go. These commands are moved to the command queue at the appropriate time, either when the @wait time elapses, or when the semaphore is @notified.
   
   You can see which commands are currently queued with the @ps command, and with the getpids(), lpids() and pidinfo() functions. Queued commands can be cancelled with @halt and/or @drain.
 
-Continued in 'help queue3'.
+Continued in 'help queue2'.
 & QUEUE3
-  There are several @config options which affect queueing. The option 'player_queue_limit' controls how many action lists can be queued by one object at any given time. Wizards and objects with the Queue @power can queue more commands (equal to the player_queue_limit plus the current number of objects in the database, including garbage).
+  There are several @config options which affect queueing.
+
+  The option 'player_queue_limit' controls how many action lists can be queued by one object at any given time. Wizards and objects with the Queue @power can queue more commands (equal to the player_queue_limit plus the current number of objects in the database, including garbage).
   
   Normally each object has its own queue count, but if the 'owner_queues' option is enabled, objects share a queue count with their owner.
   
-  'queue_chunk' and 'active_queue_chunk' control how quickly commands are executed from the queue.
+  'queue_chunk' controls how many commands PennMUSH runs before checking again for incoming socket commands or connections.
   
   It costs a certain number of pennies to queue an action list; the exact amount is set in the 'queue_cost' @config option. These pennies are returned after the action list is run. Sometimes, you'll lose a penny when queueing a command; the chance of this happening is controlled by the 'queue_loss' option.
   

--- a/game/txt/hlp/pennv188.hlp
+++ b/game/txt/hlp/pennv188.hlp
@@ -38,7 +38,6 @@ Major Changes:
 Minor Changes:
 
 * Sockets commands now inline $-commands, so, e.g: $,* *: chat aliases don’t hit queue. [GM]
-=======
 * Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
 * Sqlite3’s [1mREGEXP[0m operator is always available and uses pcre regular expressions (Previously it depended on libicu and used java style REs). [SW]
 

--- a/game/txt/hlp/pennv188.hlp
+++ b/game/txt/hlp/pennv188.hlp
@@ -17,6 +17,8 @@ be read in 'help patchlevels'.
 Major Changes:
 
 * Built-in HTTP server support, see “help http” [GM]
+* A single command queue for players and objects. No more @trigger waits. [GM]
+* A restructuring of bsd.c, to make it easier to reason about Penn’s queue cycle. [GM]
 
 Minor Changes:
 
@@ -29,3 +31,8 @@ Softcode:
 * [1mformdecode()[0m for decoding HTTP paths and POST bodies. [GM]
 * [1m@respond[0m for manipulating HTTP response codes and headers. [GM]
 * [1mhmac()[0m for creating authentication fingerprints. [SW]
+
+Fixes:
+
+* [1madd_function[0m in .cnf files was not properly using the upper case’d string. [#1223, MT]
+* Various PCRE calls in the softcode have had CPU time limit watchdogs added. Discovered by Ashen-Shugar. [GM]

--- a/game/txt/hlp/pennv188.hlp
+++ b/game/txt/hlp/pennv188.hlp
@@ -25,7 +25,7 @@ As an example, this used to be a common way to ensure something was executed onc
 
 
 
-This will now happen, up to several thousand times per second! Add in an @wait 1, and it’ll work as expected!
+This will now happen up to several thousand times per second! Add in an @wait 1, and it’ll work as expected!
 
 
 Major Changes:

--- a/game/txt/hlp/pennv188.hlp
+++ b/game/txt/hlp/pennv188.hlp
@@ -14,15 +14,30 @@ A list of the patchlevels associated with each release can
 be read in 'help patchlevels'.
 
 
+WARNING! With the removal of the object queue, please be careful when upgrading that you do not have any infinitely looping triggers without an @wait.
+
+
+As an example, this used to be a common way to ensure something was executed once per second:
+
+
+
+&everysecond object=do some ; updates ; @trigger me/everysecond
+
+
+
+This will now happen, up to several thousand times per second! Add in an @wait 1, and it’ll work as expected!
+
+
 Major Changes:
 
 * Built-in HTTP server support, see “help http” [GM]
 * A single command queue for players and objects. No more @trigger waits. [GM]
 * A restructuring of bsd.c, to make it easier to reason about Penn’s queue cycle. [GM]
+* Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
 
 Minor Changes:
 
-* Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
+* Sockets commands now inline $-commands, so, e.g: $,* *: chat aliases don’t hit queue. [GM]
 
 Softcode:
 

--- a/hdrs/conf.h
+++ b/hdrs/conf.h
@@ -197,8 +197,6 @@ struct options_table {
   int player_queue_limit; /**< Maximum commands a player can queue at once */
   int queue_chunk;    /**< Number of commands run from queue when no input from
                          sockets is waiting */
-  int active_q_chunk; /**< Number of commands run from queue when input from
-                         sockets is waiting */
   int func_nest_lim;  /**< Maximum function recursion depth */
   int func_invk_lim;  /**< Maximum number of function invocations */
   int call_lim;       /**< Maximum parser calls allowed in a queue cycle */

--- a/hdrs/mushtype.h
+++ b/hdrs/mushtype.h
@@ -9,6 +9,7 @@
 
 #include "copyrite.h"
 #include <openssl/ssl.h>
+#include <signal.h>
 
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
@@ -289,6 +290,9 @@ struct squeue {
   char *event;         /** Softcode Event name to trigger, or NULL if none */
   struct squeue *next; /** Pointer to next squeue event in linked list */
 };
+
+/**< Have we used too much CPU? */
+extern volatile sig_atomic_t cpu_time_limit_hit;
 
 #define HTTP_METHOD_LEN 16
 #define HTTP_CODE_LEN   64

--- a/hdrs/mushtype.h
+++ b/hdrs/mushtype.h
@@ -236,7 +236,7 @@ struct text_queue {
 
 /** An unrecoverable error happened when trying to read or write to the socket.
  * Close when safe. */
-#define CONN_SOCKET_ERROR 0x1000
+#define CONN_SHUTDOWN 0x1000
 
 /** Negotiated GMCP via Telnet */
 #define CONN_GMCP 0x2000
@@ -344,7 +344,6 @@ struct descriptor_data {
   int hide;                 /**< Hide status */
   uint32_t conn_flags;      /**< Flags of connection (telnet status, etc.) */
   struct descriptor_data *next; /**< Next descriptor in linked list */
-  struct descriptor_data *prev; /**< Previous descriptor in linked list */
   unsigned long input_chars;    /**< Characters received */
   unsigned long output_chars;   /**< Characters sent */
   int width;                    /**< Screen width */
@@ -359,7 +358,8 @@ struct descriptor_data {
   uint64_t ws_frame_len;
 #endif                /* undef WITHOUT_WEBSOCKETS */
   int64_t connlog_id; /**< ID for this connection's connlog entry */
-
+  const char *close_reason; /**< Why is this socket being closed? */
+  dbref closer;             /**< Who closed this socket? */
   struct http_request *http_request;
 };
 

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1357,6 +1357,7 @@ atr_iter_get(dbref player, dbref thing, const char *name, unsigned flags,
       result = func(player, thing, NOTHING, name, ptr, args);
   } else if (AttrCount(thing)) {
     ATTR_FOR_EACH (thing, ptr) {
+      if (cpu_time_limit_hit) break;
       if (strchr(AL_NAME(ptr), '`')) {
         continue;
       }
@@ -1483,8 +1484,10 @@ atr_iter_get_parent(dbref player, dbref thing, const char *name, unsigned flags,
     int parent_depth;
     st_init(&seen, "AttrsSeenTree");
     for (parent_depth = MAX_PARENTS + 1, parent = thing;
-         parent_depth-- && parent != NOTHING; parent = Parent(parent)) {
+         parent_depth-- && parent != NOTHING && !cpu_time_limit_hit;
+         parent = Parent(parent)) {
       ATTR_FOR_EACH (parent, ptr) {
+        if (cpu_time_limit_hit) break;
         if (!st_find(AL_NAME(ptr), &seen)) {
           st_insert(AL_NAME(ptr), &seen);
           if (parent != thing) {
@@ -1828,6 +1831,7 @@ atr_comm_match(dbref thing, dbref player, int type, int end, char const *str,
     st_flush(&private_attrs);
 
     ATTR_FOR_EACH (current, ptr) {
+      if (cpu_time_limit_hit) break;
       if (current == thing) {
         if (st_find(AL_NAME(ptr), &nocmd_roots)) {
           continue;
@@ -1999,7 +2003,7 @@ atr_comm_match(dbref thing, dbref player, int type, int end, char const *str,
         }
       }
     }
-  } while ((current = next) != NOTHING);
+  } while ((current = next) != NOTHING && !cpu_time_limit_hit);
 
   st_flush(&seen);
   st_flush(&nocmd_roots);

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -1,7 +1,7 @@
 /**
  * \file bsd.c
  *
- * \brief Network communication through BSD sockets for PennMUSH.
+ * \brief Network communication through BSD sockets for PennMUSH.->reas
  *
  * While mysocket.c provides low-level functions for working with
  * sockets, bsd.c focuses on player descriptors, a higher-level
@@ -7200,7 +7200,7 @@ close_ssl_connections(void)
       ssl_close_connection(d->ssl);
       d->ssl = NULL;
       d->conn_flags |= CONN_CLOSE_READY;
-      d->reason = "ssl shutdown";
+      d->close_reason = "ssl shutdown";
     }
   }
   /* Close server socket */

--- a/src/conf.c
+++ b/src/conf.c
@@ -226,7 +226,6 @@ PENNCONF conftable[] = {
    "limits"},
   {"queue_loss", cf_int, &options.queue_loss, 10000, 0, "limits"},
   {"queue_chunk", cf_int, &options.queue_chunk, 100000, 0, "limits"},
-  {"active_queue_chunk", cf_int, &options.active_q_chunk, 100000, 0, "limits"},
   {"function_recursion_limit", cf_int, &options.func_nest_lim, 100000, 0,
    "limits"},
   {"function_invocation_limit", cf_int, &options.func_invk_lim, 100000, 0,
@@ -1205,7 +1204,6 @@ conf_default_set(void)
   options.starting_quota = 20;
   options.player_queue_limit = 100;
   options.queue_chunk = 3;
-  options.active_q_chunk = 0;
   options.func_nest_lim = 50;
   options.func_invk_lim = 2500;
   options.call_lim = 0;

--- a/src/cque.c
+++ b/src/cque.c
@@ -2059,9 +2059,9 @@ do_queue(dbref player, const char *what, enum queue_type flag)
   dbref victim = NOTHING;
   int all = 0;
   int quick = 0;
-  int dpq = 0, doq = 0, dwq = 0, dsq = 0;
-  int pq = 0, oq = 0, wq = 0, sq = 0;
-  int tpq = 0, toq = 0, twq = 0, tsq = 0;
+  int dpq = 0, dwq = 0, dsq = 0;
+  int pq = 0, wq = 0, sq = 0;
+  int tpq = 0, twq = 0, tsq = 0;
   if (flag == QUEUE_SUMMARY || flag == QUEUE_QUICK)
     quick = 1;
   if (flag == QUEUE_ALL || flag == QUEUE_SUMMARY) {

--- a/src/cque.c
+++ b/src/cque.c
@@ -60,7 +60,6 @@ static uint32_t top_pid = 1;
 #define MAX_PID (1U << 15)
 
 static MQUE *qfirst = NULL, *qlast = NULL, *qwait = NULL;
-static MQUE *qlfirst = NULL, *qllast = NULL;
 static MQUE *qsemfirst = NULL, *qsemlast = NULL;
 
 static int add_to_generic(dbref player, int am, const char *name,
@@ -92,9 +91,6 @@ int32_t queue_load_record[QUEUE_LOAD_SECS]
   __attribute__((__aligned__(16))) = {0};
 
 double average32(const int32_t *arr, int count);
-
-extern volatile sig_atomic_t
-  cpu_time_limit_hit; /**< Have we used too much CPU? */
 
 /* From game.c, for report() */
 extern char report_cmd[BUFFER_LEN];
@@ -509,20 +505,11 @@ queue_event(dbref enactor, const char *event, const char *fmt, ...)
   /* Hmm, should events queue ahead of anything else?
    * For now, yes, but leaving code here anyway.
    */
-  if (1) {
-    if (qlast) {
-      qlast->next = tmp;
-      qlast = tmp;
-    } else {
-      qlast = qfirst = tmp;
-    }
+  if (qlast) {
+    qlast->next = tmp;
+    qlast = tmp;
   } else {
-    if (qllast) {
-      qllast->next = tmp;
-      qllast = tmp;
-    } else {
-      qllast = qlfirst = tmp;
-    }
+    qlast = qfirst = tmp;
   }
 
   /* All good! */
@@ -575,19 +562,12 @@ insert_que(MQUE *queue_entry, MQUE *parent_queue)
   switch (
     (queue_entry->queue_type & (QUEUE_PLAYER | QUEUE_OBJECT | QUEUE_INPLACE))) {
   case QUEUE_PLAYER:
+  case QUEUE_OBJECT:
     if (qlast) {
       qlast->next = queue_entry;
       qlast = queue_entry;
     } else {
       qlast = qfirst = queue_entry;
-    }
-    break;
-  case QUEUE_OBJECT:
-    if (qllast) {
-      qllast->next = queue_entry;
-      qllast = queue_entry;
-    } else {
-      qllast = qlfirst = queue_entry;
     }
     break;
   case QUEUE_INPLACE:
@@ -1028,39 +1008,17 @@ queue_update(void)
   }
   last_mudtime = mudtime;
 
-  /* move contents of low priority queue onto end of normal one
-   * this helps to keep objects from getting out of control since
-   * its effects on other objects happen only after one second
-   * this should allow @halt to be typed before getting blown away
-   * by scrolling text.
-   */
-  if (qlfirst) {
-    if (qlast)
-      qlast->next = qlfirst;
-    else
-      qfirst = qlfirst;
-    qlast = qllast;
-    qllast = qlfirst = NULL;
-  }
-
   /* check regular @wait queue */
   while (qwait && qwait->wait_until <= mudtime) {
     point = qwait;
     qwait = point->next;
     point->next = NULL;
     point->wait_until = 0;
-    if ((point->enactor < 0) || IsPlayer(point->enactor)) {
-      if (qlast) {
-        qlast->next = point;
-        qlast = point;
-      } else
-        qlast = qfirst = point;
+    if (qlast) {
+      qlast->next = point;
+      qlast = point;
     } else {
-      if (qllast) {
-        qllast->next = point;
-        qllast = point;
-      } else
-        qllast = qlfirst = point;
+      qlast = qfirst = point;
     }
   }
 
@@ -1079,18 +1037,11 @@ queue_update(void)
     add_to_sem(point->semaphore_obj, -1, point->semaphore_attr);
     point->semaphore_obj = NOTHING;
     point->next = NULL;
-    if (IsPlayer(point->enactor)) {
-      if (qlast) {
-        qlast->next = point;
-        qlast = point;
-      } else
-        qlast = qfirst = point;
+    if (qlast) {
+      qlast->next = point;
+      qlast = point;
     } else {
-      if (qllast) {
-        qllast->next = point;
-        qllast = point;
-      } else
-        qllast = qlfirst = point;
+      qlast = qfirst = point;
     }
   }
 }
@@ -1321,14 +1272,9 @@ queue_msecs_till_next(void)
   if (qfirst != NULL)
     return 0;
 
-  /* If there are commands in the object queue, they should be run in
-   * one second (asuming no @waits demanding time sooner)
-   */
-  if (qlfirst != NULL) {
-    min = SECS_TO_MSECS(1);
-  } else {
-    min = SECS_TO_MSECS(500);
-  }
+  /* Arbitrarily high wait */
+  min = SECS_TO_MSECS(500);
+
   /* Check out the wait and semaphore queues, looking for the smallest
    * wait value. Return that - 1, since commands get moved to the player
    * queue when they have one second to go.
@@ -1410,21 +1356,12 @@ execute_one_semaphore(dbref thing, char const *aname, PE_REGS *pe_regs)
       pe_regs_copystack(entry->pe_info->regvals, pe_regs, PE_REGS_QUEUE, 1);
     }
 
-    /* Place entry into the player or object queue. */
-    if (IsPlayer(entry->enactor)) {
-      if (qlast) {
-        qlast->next = entry;
-        qlast = entry;
-      } else {
-        qlast = qfirst = entry;
-      }
+    /* And enqueue */
+    if (qlast) {
+      qlast->next = entry;
+      qlast = entry;
     } else {
-      if (qllast) {
-        qllast->next = entry;
-        qllast = entry;
-      } else {
-        qllast = qlfirst = entry;
-      }
+      qlast = qfirst = entry;
     }
     return 1;
   }
@@ -1481,19 +1418,12 @@ dequeue_semaphores(dbref thing, char const *aname, int count, int all,
       giveto(entry->executor, QUEUE_COST);
       add_to(entry->executor, -1);
       free_qentry(entry);
-    } else if (IsPlayer(entry->enactor)) {
+    } else {
       if (qlast) {
         qlast->next = entry;
         qlast = entry;
       } else {
         qlast = qfirst = entry;
-      }
-    } else {
-      if (qllast) {
-        qllast->next = entry;
-        qllast = entry;
-      } else {
-        qllast = qlfirst = entry;
       }
     }
   }
@@ -2165,11 +2095,8 @@ do_queue(dbref player, const char *what, enum queue_type flag)
     }
     victim = Owner(victim);
     if (!quick)
-      notify(player, T("Player Queue:"));
+      notify(player, T("Command Queue:"));
     show_queue(player, victim, 0, quick, all, qfirst, &tpq, &pq, &dpq);
-    if (!quick)
-      notify(player, T("Object Queue:"));
-    show_queue(player, victim, 0, quick, all, qlfirst, &toq, &oq, &doq);
     if (!quick)
       notify(player, T("Wait Queue:"));
     show_queue(player, victim, 1, quick, all, qwait, &twq, &wq, &dwq);
@@ -2179,9 +2106,9 @@ do_queue(dbref player, const char *what, enum queue_type flag)
     if (!quick)
       notify(player, T("------------  Queue Done  ------------"));
     notify_format(player,
-                  T("Totals: Player...%d/%d[%ddel]  Object...%d/%d[%ddel]  "
+                  T("Totals: Player...%d/%d[%ddel]  "
                     "Wait...%d/%d[%ddel]  Semaphore...%d/%d"),
-                  pq, tpq, dpq, oq, toq, doq, wq, twq, dwq, sq, tsq);
+                  pq, tpq, dpq, wq, twq, dwq, sq, tsq);
     notify_format(player, T("Load average (1/5/15 minutes): %.2f %.2f %.2f"),
                   average32(queue_load_record, 60),
                   average32(queue_load_record, 300),
@@ -2251,20 +2178,14 @@ do_halt(dbref owner, const char *ncom, dbref victim)
   if (!Quiet(Owner(player)))
     notify_format(Owner(player), "%s: %s(#%d)", T("Halted"),
                   AName(player, AN_SYS, NULL), player);
-  for (tmp = qfirst; tmp; tmp = tmp->next)
+  for (tmp = qfirst; tmp; tmp = tmp->next) {
     if (GoodObject(tmp->executor) &&
         ((tmp->executor == player) || (Owner(tmp->executor) == player))) {
       num--;
       giveto(player, QUEUE_COST);
       tmp->executor = NOTHING;
     }
-  for (tmp = qlfirst; tmp; tmp = tmp->next)
-    if (GoodObject(tmp->executor) &&
-        ((tmp->executor == player) || (Owner(tmp->executor) == player))) {
-      num--;
-      giveto(player, QUEUE_COST);
-      tmp->executor = NOTHING;
-    }
+  }
   /* remove wait q stuff */
   for (point = qwait; point; point = next) {
     if (((point->executor == player) || (Owner(point->executor) == player))) {
@@ -2275,8 +2196,9 @@ do_halt(dbref owner, const char *ncom, dbref victim)
       else
         qwait = next = point->next;
       free_qentry(point);
-    } else
+    } else {
       next = (trail = point)->next;
+    }
   }
 
   /* clear semaphore queue */
@@ -2537,7 +2459,6 @@ void
 shutdown_queues(void)
 {
   shutdown_a_queue(&qfirst, &qlast);
-  shutdown_a_queue(&qlfirst, &qllast);
   shutdown_a_queue(&qsemfirst, &qsemlast);
   shutdown_a_queue(&qwait, NULL);
 }

--- a/src/funlist.c
+++ b/src/funlist.c
@@ -2630,7 +2630,7 @@ FUNCTION(fun_regreplace)
   pe_regs = pe_regs_localize(pe_info, PE_REGS_REGEXP, "fun_regreplace");
 
   /* Ansi-less regedits */
-  for (i = 1; i < nargs - 1; i += 2) {
+  for (i = 1; i < nargs - 1 && !cpu_time_limit_hit; i += 2) {
     /* If this string has ANSI, switch to using ansi only */
     if (has_markup(postbuf))
       break;
@@ -2742,7 +2742,7 @@ FUNCTION(fun_regreplace)
       /* Make sure we advance at least 1 char */
       if (offsets[0] == match_offset)
         match_offset++;
-    } while (all && match_offset < prelen &&
+    } while (all && match_offset < prelen && !cpu_time_limit_hit &&
              (subpatterns = pcre_exec(re, extra, prebuf, prelen, match_offset,
                                       0, offsets, 99)) >= 0);
 
@@ -2767,7 +2767,7 @@ FUNCTION(fun_regreplace)
     orig = parse_ansi_string(postbuf);
 
     /* For each search/replace pair, compare them against orig */
-    for (; i < nargs - 1; i += 2) {
+    for (; i < nargs - 1 && !cpu_time_limit_hit; i += 2) {
 
       /* Get the needle */
       tbp = tbuf;
@@ -2860,7 +2860,7 @@ FUNCTION(fun_regreplace)
             break;
           }
         }
-      } while (subpatterns >= 0 && all);
+      } while (subpatterns >= 0 && !cpu_time_limit_hit && all);
       pcre_free(re);
       DEL_CHECK("pcre");
       if (study != NULL) {
@@ -3085,7 +3085,7 @@ FUNCTION(fun_regrab)
   if (!ptrs)
     mush_panic("Unable to allocate memory in fun_regrab");
   nptrs = list2arr_ansi(ptrs, MAX_SORTSIZE, s, sep, 1);
-  for (i = 0; i < nptrs; i++) {
+  for (i = 0; i < nptrs && !cpu_time_limit_hit; i++) {
     r = remove_markup(ptrs[i], &rlen);
     if (pcre_exec(re, extra, r, rlen - 1, 0, 0, offsets, 99) >= 0) {
       if (all && *bp != b)

--- a/src/funmisc.c
+++ b/src/funmisc.c
@@ -1035,7 +1035,7 @@ FUNCTION(fun_reswitch)
 
   /* try matching, return match immediately when found */
 
-  for (j = 1; j < (nargs - 1); j += 2) {
+  for (j = 1; j < (nargs - 1) && !cpu_time_limit_hit; j += 2) {
     dp = pstr;
     sp = args[j];
     if (process_expression(pstr, &dp, &sp, executor, caller, enactor, eflags,

--- a/src/game.c
+++ b/src/game.c
@@ -1198,6 +1198,9 @@ process_command(dbref executor, char *command, MQUE *queue_entry)
   if (queue_entry->queue_type & QUEUE_DEBUG_PRIVS)
     queue_flags |= QUEUE_DEBUG_PRIVS;
 
+  if (queue_entry->queue_type & QUEUE_SOCKET)
+    queue_flags |= QUEUE_INPLACE;
+
   /* ignore null commands that aren't from players */
   if ((!command || !*command) && !(queue_entry->queue_type & QUEUE_SOCKET))
     return;
@@ -1219,7 +1222,9 @@ process_command(dbref executor, char *command, MQUE *queue_entry)
 
   strcpy(unp, command);
 
+  /* Check all our hardcoded commands, chat tokens, etc. Returns if no match. */
   cptr = command_parse(executor, command, queue_entry);
+
   if (cptr) {
     if (queue_entry->pe_info->cmd_evaled) {
       mush_free(queue_entry->pe_info->cmd_evaled, "string");

--- a/src/notify.c
+++ b/src/notify.c
@@ -454,7 +454,7 @@ notify_type(DESC *d)
     type |= MSG_ANSI2;
   }
 
-  if ((d->conn_flags & CONN_STRIPACCENTS) || (d->connected && 
+  if ((d->conn_flags & CONN_STRIPACCENTS) || (d->connected &&
       IS(d->player, TYPE_PLAYER, "NOACCENTS"))) {
     type |= MSG_STRIPACCENTS;
   }
@@ -1935,11 +1935,12 @@ int
 queue_newwrite_channel(DESC *d, const char *b, int n, char ch)
 #endif /* undef WITHOUT_WEBSOCKETS */
 {
+
   int space;
 
   char *utf8 = NULL;
 
-  if (d->conn_flags & CONN_SOCKET_ERROR)
+  if (d->conn_flags & CONN_SHUTDOWN)
     return 0;
 
   if (d->conn_flags & CONN_HTTP_BUFFER) {
@@ -1993,7 +1994,9 @@ queue_newwrite_channel(DESC *d, const char *b, int n, char ch)
           LT_TRACE,
           "send() returned %d (error %s) trying to write %d bytes to %d",
           written, strerror(errno), n, d->descriptor);
-        d->conn_flags |= CONN_SOCKET_ERROR;
+        d->conn_flags |= CONN_SHUTDOWN;
+        d->closer = GOD;
+        d->close_reason = "socket error";
         if (utf8)
           mush_free(utf8, "string");
         return 0;

--- a/src/parse.c
+++ b/src/parse.c
@@ -46,7 +46,6 @@ int global_fun_recursions;
 /* extern int re_subpatterns; */
 /* extern int *re_offsets; */
 /* extern ansi_string *re_from; */
-extern volatile sig_atomic_t cpu_time_limit_hit;
 extern int cpu_limit_warning_sent;
 
 /** Structure for storing DEBUG output in a linked list */

--- a/src/predicat.c
+++ b/src/predicat.c
@@ -1472,7 +1472,7 @@ regrep_helper(dbref player, dbref thing __attribute__((__unused__)),
     free_ansi_string(orig);
     return 0;
   }
-  while (subpatterns >= 0) {
+  while (subpatterns >= 0 && !cpu_time_limit_hit) {
     safe_str(ANSI_HILITE, rbuff, &rbp);
     ansi_pcre_copy_substring(orig, offsets, subpatterns, 0, 0, rbuff, &rbp);
     safe_str(ANSI_END, rbuff, &rbp);

--- a/src/set.c
+++ b/src/set.c
@@ -1127,7 +1127,7 @@ regedit_helper(dbref player, dbref thing,
       }
     }
   } while (subpatterns >= 0 && !(gargs->flags & EDIT_FIRST) &&
-           !gargs->call_limit_hit);
+           !gargs->call_limit_hit && !cpu_time_limit_hit);
 
   if (gargs->call_limit_hit) {
     /* Bail out */

--- a/test/testatree.pl
+++ b/test/testatree.pl
@@ -166,37 +166,29 @@ test('atree.command.6', $mortal, '&bar parent=$bar:say Parent Bar', 'Set');
 test('atree.command.7', $mortal, '&bar`baz parent=$bar`baz:say Parent Baz', []);
 test('atree.command.8', $mortal, '@set child=!no_command', 'set');
 # Do commands work from parent?
-test('atree.command.9', $god, 'bar', '!Bar');
-test('atree.command.10', $god, undef, 'Parent Bar');
-test('atree.command.11', $god, 'bar`baz', []);
-test('atree.command.12', $god, undef, 'Parent Baz');
+test('atree.command.9', $god, 'bar', 'Parent Bar');
+test('atree.command.11', $god, 'bar`baz', 'Parent Baz');
 # Child should block parent
 test('atree.command.13', $mortal, '&bar child=$bar:say Child!', 'Set');
-test('atree.command.14', $god, 'bar', '!Bar');
-test('atree.command.15', $god, undef, ['!Bar', 'Child']);
+test('atree.command.14', $god, 'bar', ['!Bar', 'Child']);
 # Child no_command blocks parent branch, too
 test('atree.command.16', $mortal, '@set child/bar=no_command', 'set');
-test('atree.command.17', $god, 'bar`baz', '!Baz');
-test('atree.command.18', $god, undef, '!Baz');
+test('atree.command.17', $god, 'bar`baz', 'Huh?');
 # Parent no_command not masked by child not no_command...
 test('atree.command.19', $mortal, '@set child/bar=!no_command', 'set');
 test('atree.command.20', $mortal, '@set parent/bar=no_command', 'set');
-test('atree.command.21', $god, 'bar`baz', '!Baz');
-test('atree.command.22', $god, undef, '!Baz');
+test('atree.command.21', $god, 'bar`baz', 'Huh?');
 # no_command can be on the leaf, too
 test('atree.command.23', $mortal, '@set parent/bar=!no_command', 'set');
 test('atree.command.24', $mortal, '@set parent/bar`baz=no_command', 'set');
-test('atree.command.25', $god, 'bar`baz', '!Baz');
-test('atree.command.26', $god, undef, '!Baz');
+test('atree.command.25', $god, 'bar`baz', 'Huh?');
 # no_inherit trumps no_command
 test('atree.command.27', $mortal, '@set parent/bar=no_inherit', 'set');
 test('atree.command.28', $mortal, '@set parent/bar`baz=no_command', 'set');
-test('atree.command.29', $god, 'bar`baz', '!Baz');
-test('atree.command.30', $god, undef, 'Grand Baz');
+test('atree.command.29', $god, 'bar`baz', 'Grand Baz');
 test('atree.command.31', $mortal, '@set parent/bar=no_command', 'set');
 test('atree.command.32', $mortal, '&bar child', []);
-test('atree.command.33', $god, 'bar', '!Baz');
-test('atree.command.34', $god, undef, 'Grand Bar');
+test('atree.command.33', $god, 'bar', 'Grand Bar');
 
 # Test for the child recognition bugs:
 test('atree.sortorder.1', $mortal, '&abc grand=$abc:say Grand ABC', 'Set');
@@ -209,37 +201,29 @@ test("atree.sortorder.7", $god, 'examine parent', 'ABC \[.*`\]');
 test("atree.sortorder.8", $god, '&abc parent', '!Cleared');
 test('atree.sortorder.9', $mortal, '@set child=!no_command', 'set');
 # Do commands work from parent?
-test('atree.sortorder.10', $god, 'abc', '!ABC');
-test('atree.sortorder.11', $god, undef, 'Parent ABC');
-test('atree.sortorder.12', $god, 'abc`xyz', []);
-test('atree.sortorder.13', $god, undef, 'Parent XYZ');
+test('atree.sortorder.10', $god, 'abc', 'Parent ABC');
+test('atree.sortorder.12', $god, 'abc`xyz', 'Parent XYZ');
 # Child should block parent
 test('atree.sortorder.14', $mortal, '&abc child=$abc:say Child!', 'Set');
-test('atree.sortorder.15', $god, 'abc', '!ABC');
-test('atree.sortorder.16', $god, undef, ['!ABC', 'Child']);
+test('atree.sortorder.15', $god, 'abc', ['!ABC', 'Child']);
 # Child no_command blocks parent branch, too
 test('atree.sortorder.17', $mortal, '@set child/abc=no_command', 'set');
-test('atree.sortorder.18', $god, 'abc`xyz', '!XYZ');
-test('atree.sortorder.19', $god, undef, '!XYZ');
+test('atree.sortorder.18', $god, 'abc`xyz', 'Huh?');
 # Parent no_command not masked by child not no_command...
 test('atree.sortorder.20', $mortal, '@set child/abc=!no_command', 'set');
 test('atree.sortorder.21', $mortal, '@set parent/abc=no_command', 'set');
-test('atree.sortorder.22', $god, 'abc`xyz', '!XYZ');
-test('atree.sortorder.23', $god, undef, '!XYZ');
+test('atree.sortorder.22', $god, 'abc`xyz', 'Huh?');
 # no_command can be on the leaf, too
 test('atree.sortorder.24', $mortal, '@set parent/abc=!no_command', 'set');
 test('atree.sortorder.25', $mortal, '@set parent/abc`xyz=no_command', 'set');
-test('atree.sortorder.26', $god, 'abc`xyz', '!XYZ');
-test('atree.sortorder.27', $god, undef, '!XYZ');
+test('atree.sortorder.26', $god, 'abc`xyz', 'Huh?');
 # no_inherit trumps no_command
 test('atree.sortorder.28', $mortal, '@set parent/abc=no_inherit', 'set');
 test('atree.sortorder.29', $mortal, '@set parent/abc`xyz=no_command', 'set');
-test('atree.sortorder.30', $god, 'abc`xyz', '!XYZ');
-test('atree.sortorder.31', $god, undef, 'Grand XYZ');
+test('atree.sortorder.30', $god, 'abc`xyz', 'Grand XYZ');
 test('atree.sortorder.32', $mortal, '@set parent/abc=no_command', 'set');
 test('atree.sortorder.33', $mortal, '&abc child', []);
-test('atree.sortorder.34', $god, 'abc', '!XYZ');
-test('atree.sortorder.35', $god, undef, 'Grand ABC');
+test('atree.sortorder.34', $god, 'abc', 'Grand ABC');
 # wipe check
 test("atree.sortorder.36", $god, '@wipe parent', 'wiped');
 test("atree.sortorder.37", $god, '@wipe grand/abc', []);


### PR DESCRIPTION
WARNING! With the removal of the object queue, please be careful when upgrading that you do
 not have any infinitely looping triggers without an `@wait`.

As an example, this used to be a common way to ensure something was executed once per second:

> `&everysecond object=do some ; updates ; @trigger me/everysecond`

This will now happen, up to several thousand times per second! Make it `@wait 1`, and it'll run once/second!

* A single command queue for players and objects. No more `@trigger` waits. [GM]
* A restructuring of bsd.c, to make it easier to reason about Penn's queue cycle. [GM]

On the way to doing this:

* cpu_timer_hit checks in atr_iter* and regexp loops (Ashen-Shugar can hang Penn for a full second w/ regrab on a single attr. Never mind max_attrs!)
* Removal of active_q_chunk - I don't think it makes much sense to have it. Instead we just run queue_chunk every loop.