### PR TITLE
Add --disable-socket-quota for unit tests

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -43,6 +43,7 @@ Minor Changes
 * Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
 * Sqlite3's `REGEXP` operator is always available and uses pcre regular expressions (Previously it depended on libicu and used java style REs). [SW]
 * Update `local.dst` to include example of millisecond callback loop. [MT]
+* Add '--disable-socket-quota' option for our test suite [GM]
 
 Softcode
 --------

--- a/game/txt/hlp/pennv187.hlp
+++ b/game/txt/hlp/pennv187.hlp
@@ -1,6 +1,17 @@
 & 1.8.7p1
 Version 1.8.7 patchlevel 1 ??? ?? 20??
 
+Minor Changes:
+
+* [1mhelp/search[0m takes a [1m/brief[0m switch to display just the names of
+matching entries. [SW]
+* help full text search includes @ and + in tokens, so things like
+[1mhelp/search "@force"[0m work as expected. Also enabled porter
+stemming of search phrases (Searching for [1mwizard[0m matches
+[1mwizards[0m). Noticed by [MG]. [SW]
+* Add [1mhelp/find[0m which mimics the pre-1.8.7 behavior of
+[1mhelp/search[0m. Suggested by [MG]. [SW]
+
 Fixes:
 
 * [1mconnrecord()[0m returns an error if extended connection logging is disabled. [SW]

--- a/game/txt/hlp/pennv188.hlp
+++ b/game/txt/hlp/pennv188.hlp
@@ -39,6 +39,7 @@ Minor Changes:
 * Millisecond timing in bsd.c for polling waits in prep for subsecond @waits. [GM]
 * Sqlite3’s [1mREGEXP[0m operator is always available and uses pcre regular expressions (Previously it depended on libicu and used java style REs). [SW]
 * Update [1mlocal.dst[0m to include example of millisecond callback loop. [MT]
+* Add ‘–disable-socket-quota’ option for our test suite [GM]
 
 Softcode:
 

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -165,6 +165,8 @@ void report_mssp(DESC *d, char *buff, char **bp);
 static int login_number = 0;
 static int under_limit = 1;
 
+static bool disable_socket_quota = false;
+
 char cf_motd_msg[BUFFER_LEN] = {'\0'};     /**< The message of the day */
 char cf_wizmotd_msg[BUFFER_LEN] = {'\0'};  /**< The wizard motd */
 char cf_downmotd_msg[BUFFER_LEN] = {'\0'}; /**< The down message */
@@ -549,7 +551,9 @@ main(int argc, char **argv)
       if (argv[n][0] == '-') {
         if (strcmp(argv[n], "--no-session") == 0)
           detach_session = 0;
-        else if (strncmp(argv[n], "--pid-file", 10) == 0) {
+        else if (strcmp(argv[n], "--disable-socket-quota") == 0) {
+          disable_socket_quota = true;
+        } else if (strncmp(argv[n], "--pid-file", 10) == 0) {
           char *eq;
           if ((eq = strchr(argv[n], '=')))
             pidfile = eq + 1;
@@ -3536,8 +3540,11 @@ process_commands(void)
       /* Should they be disconnected? If so, ignore. */
       if (cdesc->conn_flags & CONN_SHUTDOWN) continue;
 
-      if (cdesc->quota >= MS_PER_SEC && (t = cdesc->input.head) != NULL) {
+      if ((t = cdesc->input.head) != NULL) {
         enum comm_res retval;
+      
+        if (cdesc->quota < MS_PER_SEC && !disable_socket_quota)
+          continue;
 
         cdesc->quota -= MS_PER_SEC;
         nprocessed += 1;

--- a/test/PennMUSH.pm
+++ b/test/PennMUSH.pm
@@ -83,7 +83,7 @@ sub start {
     die "Could not start game process properly; pid $child!\n";
   } elsif (defined($child)) {
     chdir("testgame");
-    my @execargs = ("./netmush", "--no-session");
+    my @execargs = ("./netmush", "--no-session", "--disable-socket-quota");
     if ($self->{VALGRIND}) {
       unshift @execargs, "valgrind", "--tool=memcheck", '--log-file=../valgrind-%p.log',
 	"--leak-check=full", "--track-origins=yes";


### PR DESCRIPTION
For more details on socket quota, check GitHub issue #1221

Unit tests now run netmush with --disable-socket-quota, reducing 'make test'
run time from 6m22s to 42s