### PR TITLE
Add deprecation warning to bad uses of lit()

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -59,3 +59,4 @@ Fixes
 
 * `add_function` in .cnf files was not properly using the upper case'd string. [#1223, MT]
 * Various PCRE calls in the softcode have had CPU time limit watchdogs added. Discovered by Ashen-Shugar. [GM]
+* Added a 'deprecated version' indicator to `lit()` for when its parameters will break parser arguments. [GM]

--- a/game/txt/hlp/pennv187.hlp
+++ b/game/txt/hlp/pennv187.hlp
@@ -16,6 +16,7 @@ Fixes:
 
 * [1mconnrecord()[0m returns an error if extended connection logging is disabled. [SW]
 * [1mconnlog()[0m didn’t handle future dates very well. [SW]
+* dbtools programs couludn’t handle attributes with quote marks in the name. Reported by [MT]. [SW,1228]
 
 & 1.8.7p0
 Version 1.8.7 patchlevel 0 Aug 10 2018

--- a/game/txt/hlp/pennv188.hlp
+++ b/game/txt/hlp/pennv188.hlp
@@ -53,3 +53,4 @@ Fixes:
 
 * [1madd_function[0m in .cnf files was not properly using the upper case’d string. [#1223, MT]
 * Various PCRE calls in the softcode have had CPU time limit watchdogs added. Discovered by Ashen-Shugar. [GM]
+* Added a ‘deprecated version’ indicator to [1mlit()[0m for when its parameters will break parser arguments. [GM]


### PR DESCRIPTION
I'd really like to rewrite the parser and make its uses cleaner. `FN_LITERAL`, which is only used by `lit()`, is a big pain in my posterior because of how it alters the parser.

I'd like to switch `lit()` from `FN_LITERAL` to `FN_NOPARSE`. This PR is a first step - if `lit()` is called with mismatched, unescaped {}s or []s, this will simply warn executor and enactor.