### PR TITLE
Add function to set close-on-exec flag on descriptors.

### DIFF
--- a/CHANGES.187.md
+++ b/CHANGES.187.md
@@ -38,6 +38,7 @@ Fixes
 * `connrecord()` returns an error if extended connection logging is disabled. [SW]
 * `connlog()` didn't handle future dates very well. [SW]
 * dbtools programs couludn't handle attributes with quote marks in the name. Reported by [MT]. [SW,1228]
+* @http requests in-progress during a @shutdown/reboot would leak sockets. [SW,1246]
 
 Version 1.8.7 patchlevel 0 Aug 10 2018
 ======================================

--- a/hdrs/mysocket.h
+++ b/hdrs/mysocket.h
@@ -78,6 +78,7 @@ ssize_t recv_with_creds(int, void *, size_t, int *, int *);
 void make_nonblocking(int s);
 void make_blocking(int s);
 void set_keepalive(int s, int timeout);
+void set_close_exec(int s);
 bool is_blocking_err(int);
 
 /* Win32 uses closesocket() to close a socket, and so will we */

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1839,6 +1839,14 @@ req_write_callback(void *contents, size_t size, size_t nmemb, void *userp)
   }
 }
 
+static int
+req_set_cloexec(void *clientp __attribute__((__unused__)), curl_socket_t fd,
+                curlsocktype purpose __attribute__((__unused__)))
+{
+  set_close_exec(fd);
+  return CURL_SOCKOPT_OK;
+}
+
 #endif
 
 COMMAND(cmd_fetch)
@@ -1923,6 +1931,7 @@ COMMAND(cmd_fetch)
   curl_easy_setopt(handle, CURLOPT_VERBOSE, 0);
   curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 1);
   curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1);
+  curl_easy_setopt(handle, CURLOPT_SOCKOPTFUNCTION, req_set_cloexec);
   /* 1 minute timeouts should be more than ample for our needs */
   curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT, 60);
   curl_easy_setopt(handle, CURLOPT_TIMEOUT, 60);

--- a/src/mysocket.c
+++ b/src/mysocket.c
@@ -687,6 +687,23 @@ set_keepalive(int s __attribute__((__unused__)),
   return;
 }
 
+/** Set the CLOEXEC bit on a descriptor
+ *
+ * \param fd the file descriptor to set
+ */
+void
+set_close_exec(int fd)
+{
+#ifdef HAVE_FCNTL
+  int flags = fcntl(fd, F_GETFD);
+  if (flags < 0) {
+    return;
+  }
+  flags |= FD_CLOEXEC;
+  fcntl(fd, F_SETFD, flags);
+#endif
+}
+
 /** Connect a socket, possibly making it nonblocking first.
  * From UNP, with changes. If nsec > 0, we set the socket
  * nonblocking and connect with timeout. The socket is STILL

--- a/src/sig.c
+++ b/src/sig.c
@@ -67,33 +67,10 @@ sigrecv_setup(void)
   }
   sigrecv_fd = fds[0];
   signotifier_fd = fds[1];
-#ifdef HAVE_FCNTL
-  flags = fcntl(sigrecv_fd, F_GETFD);
-  if (flags >= 0) {
-    flags |= FD_CLOEXEC;
-    if (fcntl(sigrecv_fd, F_SETFD, flags) < 0)
-      perror("sigrecv_setup: fcntl F_SETFD");
-
-  } else {
-    perror("sigrecv_setup: fcntl F_GETFD");
-  }
-  flags = fcntl(signotifier_fd, F_GETFD);
-  if (flags >= 0) {
-    flags |= FD_CLOEXEC;
-    if (fcntl(signotifier_fd, F_SETFD, flags) < 0)
-      perror("sigrecv_setup: fcntl F_SETFD");
-  } else {
-    perror("sigrecv_setup: fcntl F_GETFD");
-  }
-  flags = fcntl(signotifier_fd, F_GETFL);
-  if (flags >= 0) {
-    flags |= O_NONBLOCK;
-    if (fcntl(signotifier_fd, F_SETFL, flags) < 0)
-      perror("sigrecv_setup: fcntl F_SETFL");
-  } else {
-    perror("sigrecv_setup: fcntl F_GETFL");
-  }
-#endif
+  set_close_exec(sigrecv_fd);
+  make_nonblocking(sigrecv_fd);
+  set_close_exec(signotifier_fd);
+  make_nonblocking(signotifier_fd);
 #endif
 #endif
 }


### PR DESCRIPTION
Use it in a few places instead of current inlined setting code, and now
in @http requests. Closes #1246 


Tested on MUSH.