### PR TITLE
Add loginfail event for connection attempts with no name given

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -238,8 +238,11 @@ connect_player(DESC *d, const char *name, const char *password,
   strcpy(errbuf,
          T("Either that player does not exist, or has a different password."));
 
-  if (!name || !*name)
+  if (!name || !*name) {
+    queue_event(SYSEVENT, "SOCKET`LOGINFAIL", "%d,%s,%d,%s,#%d,",
+                d->descriptor, ip, count, "missing player name", -1);
     return NOTHING;
+  }
 
   /* validate name */
   if ((player = lookup_player(name)) == NOTHING) {

--- a/src/player.c
+++ b/src/player.c
@@ -239,6 +239,8 @@ connect_player(DESC *d, const char *name, const char *password,
          T("Either that player does not exist, or has a different password."));
 
   if (!name || !*name) {
+    /* Missing player names are failures, too. */
+    count = mark_failed(ip);
     queue_event(SYSEVENT, "SOCKET`LOGINFAIL", "%d,%s,%d,%s,#%d,",
                 d->descriptor, ip, count, "missing player name", -1);
     return NOTHING;

--- a/src/player.c
+++ b/src/player.c
@@ -239,10 +239,9 @@ connect_player(DESC *d, const char *name, const char *password,
          T("Either that player does not exist, or has a different password."));
 
   if (!name || !*name) {
-    /* Missing player names are failures, too. */
-    count = mark_failed(ip);
+    /* Missing player names are failures, but don't count them. */
     queue_event(SYSEVENT, "SOCKET`LOGINFAIL", "%d,%s,%d,%s,#%d,",
-                d->descriptor, ip, count, "missing player name", -1);
+                d->descriptor, ip, count_failed(ip), "missing player name", -1);
     return NOTHING;
   }
 


### PR DESCRIPTION
Adds a SOCKET`LOGINFAIL event for connection attempts that don't include a name/password, e.g. just typing connect. The use case for this is a login form on the web client. If your login attempt fails, it pops the login form back up and says try again. It does this just fine when you submit the incorrect username or password, but there was an early exit condition with no event queued when the name was blank. 

Uses the same event queue arguments as the "invalid player" loginfail event, with a blank string in place of the last argument for name.