### PR TITLE
Safely encode ANSI in JSON strings.

### DIFF
--- a/src/function.c
+++ b/src/function.c
@@ -521,7 +521,7 @@ FUNTAB flist[] = {
   {"ITEMS", fun_items, 2, 2, FN_REG | FN_STRIPANSI},
   {"ITEMIZE", fun_itemize, 1, 4, FN_REG},
   {"ITEXT", fun_itext, 1, 1, FN_REG | FN_STRIPANSI},
-  {"JSON", fun_json, 1, INT_MAX, FN_REG | FN_STRIPANSI},
+  {"JSON", fun_json, 1, INT_MAX, FN_REG},
   {"JSON_MAP", fun_json_map, 2, MAX_STACK_ARGS + 1, FN_REG | FN_STRIPANSI},
   {"JSON_MOD", fun_json_mod, 3, 4, FN_REG | FN_STRIPANSI},
   {"JSON_QUERY", fun_json_query, 1, INT_MAX, FN_REG | FN_STRIPANSI},

--- a/src/funjson.c
+++ b/src/funjson.c
@@ -49,8 +49,6 @@ json_escape_string(char *input)
       // Nothing
     } else if (*p == '\t') {
       safe_str("\\t", buff, &bp);
-    } else if (*p == 0x1B) {
-      safe_str("\\u001b", buff, &bp);
     } else if (*p > 127 || *p <= 0x1F) {
       safe_format(buff, &bp, "\\u%04X", (unsigned) *p);
     } else {


### PR DESCRIPTION
EDIT: **This does not enable you to embed ANSI escape sequences.** It encodes the ANSI escape character into a printable Unicode backslash-encoding. These encodings are not interpreted by the MUSH in anyway, they are just normal strings of URL-safe printable characters. The encodings are only converted back to ANSI escape if the client parses them and chooses to do that.

This PR enables ANSI encoded strings in JSON objects.  The changes are enumerated below:

1. Remove FN_STRIPANSI from the softcode declaration for json().
2. Manually strip ANSI from all args unless we're making a JSON string.
3. Render the internal markup to ANSI and immediately pass to json_escape_string() which re-encodes the escape sequences as printable characters.

With this change the code ```json(string,ansi(r,red))``` returns ```"\u001b[31mred\u001b[0m"``` where "\u001b" is a string, not a literal \x1b escape character. Using other JSON types still strips ANSI, so something like ```json(number,ansi(r,1))``` returns ```1``` as expected.

A particular use case of this is passing the contents of an @mail through JSON to the web client. It would also be useful for passing any other pre-rendered ANSI strings (bbposts, channels, $-commands). Tested and confirmed working under Chrome's JSON.parse() implementation.