### PR TITLE
Option to use a static HTML file instead of the hardcoded MUDURL redirect.

### DIFF
--- a/game/mushcnf.dst
+++ b/game/mushcnf.dst
@@ -541,6 +541,11 @@ full_html_file txt/full.html
 # OPTIONAL
 # who_html_file
 
+# Static HTML landing page to show when someone accesses the MUSH
+# port using a web browser and no http_handler is defined.
+# OPTIONAL
+# index_html_file txt/index.html
+
 # The big text files. New ones can be added by setting up
 # a new subdirectory of game/txt as described in game/txt/README,
 # and adding a new help_command line below, or uncommenting one of

--- a/hdrs/conf.h
+++ b/hdrs/conf.h
@@ -230,6 +230,7 @@ struct options_table {
                                         files */
   char guest_file[2][FILE_PATH_LEN]; /**< Names of text and html guest files */
   char who_file[2][FILE_PATH_LEN];   /**< Names of text and html who files */
+  char index_html[FILE_PATH_LEN];    /**< Name of the default HTTP landing page */
   int log_commands;                  /**< Should we log all commands? */
   int log_forces;                    /**< Should we log force commands? */
   int support_pueblo;                /**< Should the MUSH send Pueblo tags? */

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -382,6 +382,7 @@ struct fcache_entries {
   FBLOCK full_fcache[2];     /**< full.txt and full.html */
   FBLOCK guest_fcache[2];    /**< guest.txt and guest.html */
   FBLOCK who_fcache[2];      /**< textfiles to override connect screen WHO */
+  FBLOCK index_fcache;         /**< default HTTP landing page */
 };
 
 static struct fcache_entries fcache;
@@ -2056,6 +2057,8 @@ fcache_read_one(const char *filename)
       hash_add(&lookup, options.guest_file[i], &fcache.guest_fcache[i]);
       hash_add(&lookup, options.who_file[i], &fcache.who_fcache[i]);
     }
+    
+    hash_add(&lookup, options.index_html, &fcache.index_fcache);
   }
 
   fb = hashfind(filename, &lookup);
@@ -2072,7 +2075,7 @@ fcache_read_one(const char *filename)
 void
 fcache_load(dbref player)
 {
-  int conn, motd, wiz, new, reg, quit, down, full;
+  int conn, motd, wiz, new, reg, quit, down, full, index;
   int guest, who;
   int i;
 
@@ -2087,14 +2090,18 @@ fcache_load(dbref player)
     full = fcache_read(&fcache.full_fcache[i], options.full_file[i]);
     guest = fcache_read(&fcache.guest_fcache[i], options.guest_file[i]);
     who = fcache_read(&fcache.who_fcache[i], options.who_file[i]);
+    
+    if (i == 0) {
+      index = fcache_read(&fcache.index_fcache, options.index_html);
+    }
 
     if (player != NOTHING) {
       notify_format(player,
-                    T("%s sizes:  NewUser...%d  Connect...%d  "
+                    T("%s sizes:  Index...%d  NewUser...%d  Connect...%d  "
                       "Guest...%d  Motd...%d  Wizmotd...%d  Quit...%d  "
                       "Register...%d  Down...%d  Full...%d  Who...%d"),
-                    i ? "HTMLFile" : "File", new, conn, guest, motd, wiz, quit,
-                    reg, down, full, who);
+                    i ? "HTMLFile" : "File", index, new, conn, guest, motd,
+                      wiz, quit, reg, down, full, who);
     }
   }
 }
@@ -3559,12 +3566,38 @@ http_bounce_mud_url(DESC *d)
   char buf[BUFFER_LEN];
   char *bp = buf;
   bool has_url = strncmp(MUDURL, "http", 4) == 0;
+  FBLOCK *index = &fcache.index_fcache;
+  
+  /* Setup the return headers. */
   safe_format(buf, &bp,
               "HTTP/1.1 200 OK\r\n"
               "Content-Type: text/html; charset:iso-8859-1\r\n"
               "Pragma: no-cache\r\n"
               "Connection: Close\r\n"
-              "\r\n"
+              "\r\n");
+  
+  /* See if we've got a cached index.html file and use that. */
+  if (index && index->buff) {
+    *bp = '\0';
+    
+    /* Check for an attribute override. */
+    if (index->thing != NOTHING) {
+      if (fcache_dump_attr(d, index->thing, (char *) index->buff, 1, buf, NULL) == 1) {
+        /* Attr successfully evaluated and displayed */
+        return;
+      }
+    } else {
+      /* Output static text from the cached file */
+      queue_newwrite(d, buf, strlen(buf));
+      queue_eol(d);
+      queue_write(d, index->buff, index->len);
+      return;
+    }
+    
+  }
+  
+  /* Show the default landing page with embedded MUDURL. */
+  safe_format(buf, &bp,
               "<!DOCTYPE html>\r\n"
               "<HTML><HEAD>"
               "<TITLE>Welcome to %s!</TITLE>",
@@ -7645,6 +7678,8 @@ watch_files_in(void)
     WATCH(options.guest_file[n]);
     WATCH(options.who_file[n]);
   }
+  
+  WATCH(options.index_html);
 
   for (h = hash_firstentry(&help_files); h; h = hash_nextentry(&help_files))
     WATCH(h->file);

--- a/src/conf.c
+++ b/src/conf.c
@@ -119,6 +119,8 @@ PENNCONF conftable[] = {
    sizeof options.guest_file[1], 0, "messages"},
   {"who_html_file", cf_str, options.who_file[1], sizeof options.who_file[1], 0,
    "messages"},
+  {"index_html_file", cf_str, options.index_html, sizeof options.index_html, 0,
+   "messages"},
 
   {"player_start", cf_dbref, &options.player_start, 100000, 0, "db"},
   {"master_room", cf_dbref, &options.master_room, 100000, 0, "db"},


### PR DESCRIPTION
This PR adds a configuration option 'index_html_file' which is commented out by default in mushcnf.dst. Setting the option to the path name of a static HTML file (game/txt/index.html by default) allows the game to use it as the default response for HTTP requests instead of the hardcoded redirect to MUDURL. If the option is blank or the file does not exist, we fall back to the original hardcoded redirect page. This uses the existing fcache_*() functions that are already used to load and serve up files like connect.txt/connect.html. This allows a game administrator to use a nicer redirect page or serve a small index.html for a web client that loads additional assets from the main website. 