### PR TITLE
Add NOQUOTA sockset option.

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -49,6 +49,8 @@ Minor Changes
 * The list of color definitions used with `ansi()`, `colors()`, etc. is now kept in game/txt/colors.json. [SW]
 * Sqlite3 updated to 3.25.3. Biggest user-visible change is support for window functions. [SW]
 * Update cJSON to 1.7.10 [SW]
+* @SOCKSET now has a NOQUOTA option. Descriptors set with this flag will be refreshed with QUOTA_MAX every refresh. Can only be set by a logged in wizard. [MT]
+* The "--disable-socket-quota" command line option will now persist through @shutdown/reboot.  [MT]
 
 Softcode
 --------

--- a/game/txt/hlp/penncmd.hlp
+++ b/game/txt/hlp/penncmd.hlp
@@ -1,6 +1,6 @@
 & COMMANDS
 Help is available for the following MUSH commands:
- 
+
   ahelp          anews          brief          DOING          drop
   examine        enter          events         follow         get
   give           go             index          leave          LOGOUT
@@ -9,19 +9,19 @@ Help is available for the following MUSH commands:
   teach          think          unfollow       use            whisper
   WHO            with           "              :              ;
   +              ]
- 
+
   In addition to these, there are several types of '@' commands. @-commands are usually commands which have permanent effects on the MUSH (such as creating a new object). Here are the help topics on @-commands:
- 
+
   @-ATTRIBUTES   @-BUILDING     @-GENERAL      @-WIZARD
- 
+
   Commands that can only be used by connected players are listed in HELP SOCKET COMMANDS.
 & @-ATTRIBUTES
 These '@' commands set standard message/action sets on objects. Each comes in 3 versions: @<whatever>, @o<whatever>, and @a<whatever>. Only the @<whatever> version is listed below, but help is available for each:
- 
+
   @death         @describe      @drop          @efail         @enter
   @failure       @follow        @give          @idescribe     @leave
   @lfail         @move          @payment       @receive       @success
-  @tport         @ufail         @unfollow      @use           @zenter        
+  @tport         @ufail         @unfollow      @use           @zenter
   @zleave
 
 These '@' command set other standard attributes on objects that don't follow the pattern above:
@@ -32,19 +32,19 @@ These '@' command set other standard attributes on objects that don't follow the
   @haven         @idescformat   @idle          @infilter      @inprefix
   @lalias        @listen        @nameformat    @oxenter       @oxleave
   @oxmove        @oxtport       @prefix        @runout        @sex
-  @startup       
+  @startup
 
 See also: ATTRIBUTES, NON-STANDARD ATTRIBUTES
 & @-BUILDING
 These '@' commands are building-related (they create or modify objects):
- 
-  @atrlock       @atrchown      @chown         @chzone        @clone         
-  @cpattr        @create        @destroy       @dig           @elock         
+
+  @atrlock       @atrchown      @chown         @chzone        @clone
+  @cpattr        @create        @destroy       @dig           @elock
   @eunlock       @firstexit     @link          @lock          @moniker
-  @mvattr        @name          @nuke          @open          @parent        
-  @recycle       @set           @undestroy     @ulock         @unlink        
+  @mvattr        @name          @nuke          @open          @parent
+  @recycle       @set           @undestroy     @ulock         @unlink
   @unlock        @uunlock       @wipe
-  
+
 & @-GENERAL
 These '@' commands are general utility and programming commands:
 
@@ -53,16 +53,16 @@ These '@' commands are general utility and programming commands:
   @dolist        @drain         @edit          @emit          @entrances
   @find          @force         @function      @gedit         @grep
   @halt          @lemit         @listmotd      @mail          @notify
-  @nsemit        @nslemit       @nsoemit       @nspemit       @nsprompt      
-  @nsremit       @nszemit       @oemit         @password      @pemit         
-  @prompt        @ps            @remit         @restart       @scan          
-  @search        @select        @stats         @sweep         @switch        
-  @teleport      @trigger       @verb          @version       @wait          
+  @nsemit        @nslemit       @nsoemit       @nspemit       @nsprompt
+  @nsremit       @nszemit       @oemit         @password      @pemit
+  @prompt        @ps            @remit         @restart       @scan
+  @search        @select        @stats         @sweep         @switch
+  @teleport      @trigger       @verb          @version       @wait
   @whereis       @zemit
 
 & @-WIZARD
 These '@' commands are only usable by wizards or privileged players:
- 
+
   @allhalt       @allquota      @boot          @chownall      @chzoneall
   @comment       @dbck          @disable       @dump          @enable
   @flag          @hide          @hook          @http          @kick
@@ -71,7 +71,7 @@ These '@' commands are only usable by wizards or privileged players:
   @respond       @rejectmotd    @shutdown      @sitelock      @sql
   @squota        @suggest       @uptime        @wall          @wizmotd
   @wizwall       cd             ch             cv
- 
+
 & ]
   "]" is a special prefix which can be used before any command. It instructs the MUSH that it shouldn't evaluate the arguments to the command (similar to the "/noeval" switch available on some commands). For example:
 
@@ -94,13 +94,13 @@ These '@' commands are only usable by wizards or privileged players:
 See also: lit(), decompose(), escape(), @command, }
 & ]2
   Using ']' with $-commands:
-  
+
   > &test Tester=$test *: @pemit %#=I got: %0
-  
+
   Normal evaluation:
     > test My name is %n.
     I got: My name is Wiggles.
-  
+
   Preventing the user input from being evaluated:
     > ]test My name is %n.
     I got: My name is %n.
@@ -113,18 +113,18 @@ See also: lit(), decompose(), escape(), @command, }
   In the last example, '%0' would evaluate to 'My name is Wiggles.' (because the string entered by the user was evaluated), but the @pemit has been told not to evaluate its arguments.
 & }
   "}" is a special prefix which can be used before any command. It causes the MUSH to show debug information when evaluating that command (the same as if you had the DEBUG flag set), and for any $-commands which are triggered by the command.
-  
-  In order for debug to be shown for triggered $-commands, you must either control the object(s) the matching $-commands are on, or be in the object's DEBUGFORWARDLIST attribute. 
-  
+
+  In order for debug to be shown for triggered $-commands, you must either control the object(s) the matching $-commands are on, or be in the object's DEBUGFORWARDLIST attribute.
+
 See also: DEBUG, ]
 & @@
   @@ [<text>]
- 
+
   The "@@" command does nothing; it does not evaluate its input or show any messages to the executor. It can be used for commenting code.
-  
+
   Example:
   > @va me=$testing: @emit Test ; @@ Just a test ; @vb me=Testing
-  
+
 See also: @@(), null()
 & @aclone
   @aclone <object>=<action list>
@@ -132,7 +132,7 @@ See also: @@(), null()
   Sets the actions to be taken by <object> whenever it's @cloned. This command can be useful for notifying the owner of a vending machine or parent object when someone uses the machine.
 
   Please note that there are no @clone or @oclone attributes.
-  
+
 See also: @clone, @create, ACTION LISTS
 & @aconnect
   @aconnect <object>=<action list>
@@ -143,7 +143,7 @@ See also: @clone, @create, ACTION LISTS
 
   One argument is passed to @aconnect:
   %1 = number of player connections (1 if this is an initial connect)
-  
+
   Example:
     > @aconnect me=+who ; +bbscan
 
@@ -158,9 +158,9 @@ See also: @mail
 & @odescribe
   @odescribe <object>[=<message>]
   @adescribe <object>[=<action list>]
-  
+
   These attributes contain the message shown to others in the enactor's location when he looks at <object>, and the actions to be taken by <object> when someone looks at it. (See 'help @describe' for the attribute shown to the enactor when he looks at <object>.) When the enactor is inside <object>, the @oidescribe and @aidescribe attributes will be used instead, if set. Please note that using these attributes to show long messages is often found annoying.
-  
+
   Examples:
     > @odescribe Walker=glances at Walker and sniggers.
     > @adescribe me=think %n just looked at you.
@@ -168,27 +168,27 @@ See also: @mail
 See also: look, @describe, @idescribe, ACTION LISTS
 & @adestroy
   @adestroy <object>[=<action list>]
- 
+
   The adestroy attribute is triggered when <object> is @destroyed. It can only be set by wizards. Because the attribute is triggered when <object> is @destroyed, not when the object is actually purged from the database, it's possible for <object> to be @undestroyed after the adestroy has run.
-  
+
   Please note that there are no destroy or odestroy attributes.
-  
+
 See also: @destroy, @undestroy, EVENTS
 & @adisconnect
   @adisconnect <object>[=<action list>]
 
   Sets the actions to be taken by <object> when a player disconnects from the game. @adisconnects are triggered on disconnecting players, their locations (if the room_connects @config option is true), their zone object/objects in their zone master room, and objects in the Master Room.
- 
+
   Several arguments are passed to @adisconnect:
    %1 = number of remaining connections (0 if a full disconnect)
    %2 = bytes received by the disconnecting descriptor
    %3 = bytes sent by the disconnecting descriptor
    %4 = commands issued by the disconnecting descriptor
    %5 = 1 if the descriptor was hidden on disconnect, 0 otherwise
-  
+
   Example:
   > @adisconnect me = home
- 
+
 See also: @aconnect, ACTION LISTS, recv(), sent(), cmds(), EVENTS
 & @adrop
 & @odrop
@@ -196,17 +196,17 @@ See also: @aconnect, ACTION LISTS, recv(), sent(), cmds(), EVENTS
   @drop <object>[=<message>]
   @odrop <object>[=<message>]
   @adrop <object>[=<action list>]
-  
+
   When <object> is a player or thing, the @drop attribute is shown to whoever drops <object>, and @odrop to others in the location <object> is dropped in. The @adrop attribute is triggered when <object> is dropped.
-  
+
   When <object> is an exit, @drop is shown to objects going through <object>, and @odrop is shown to objects in the exit's destination. @adrop is triggered when someone passes through the exit.
-  
+
   Example:
     > @drop Box=You put the box down gently.
     > @odrop Box=puts the box down gently.
-    
+
     > @odrop South=arrives from the North.
-  
+
 See also: drop, empty, ACTION LISTS, VERBS, @success
 & @aefail
 & @oefail
@@ -214,7 +214,7 @@ See also: drop, empty, ACTION LISTS, VERBS, @success
   @efail <object>[=<message>]
   @oefail <object>[=<message>]
   @aefail <object>[=<action list>]
-  
+
   These attributes contain the message shown to someone who fails to enter <object>, the message shown to others when someone fails to enter <object>, and the actions to be taken when someone fails to enter it, respectively.
 
 See also: enter, @enter, FAILURE, ACTION LISTS, VERBS
@@ -224,13 +224,13 @@ See also: enter, @enter, FAILURE, ACTION LISTS, VERBS
   @ufail <object>=[<message>]
   @oufail <object>=[<message>]
   @aufail <object>=[<action list>]
- 
+
   Sets the message shown to a player who fails to use an object via the 'use' command (because they don't pass the @lock/use), the message shown to others in the room when a player fails to use <object>, and the actions to be taken by <object> when someone fails to use it, respectively.
 
   Note that these attributes are @ufail, NOT @ufailure, for TinyMUSH compatibility.
-  
+
   Although the Use @lock also restricts who can trigger $-commands or ^-listens on an object, these attributes will not be triggered for those failures. Instead, the COMMAND_LOCK`* and LISTEN_LOCK`* attributes are triggered. See 'help failure' for more information.
-  
+
 See also: use, @use, FAILURE, ACTION LISTS, VERBS
 & @afailure
 & @ofailure
@@ -240,7 +240,7 @@ See also: use, @use, FAILURE, ACTION LISTS, VERBS
   @afailure <object>[=<action list>]
 
   @failure contains the message shown to someone who fails to pass <object>'s Basic @lock. @ofailure contains the message shown to others, and @afailure contains the actions to be taken by <object>.
-  
+
   For players and things, this means failure to get/take. For exits, it means failure to go through the exit. For rooms the lock is checked when objects "look" inside the room, though failure to pass the lock does not prevent the object from looking.
 
 See also: get, move, @lock, ACTION LISTS, VERBS, @success
@@ -250,7 +250,7 @@ See also: get, move, @lock, ACTION LISTS, VERBS, @success
   @follow <object>[=<message>]
   @ofollow <object>[=<message>]
   @afollow <object>[=<action list>]
-  
+
   Sets the message shown to someone who begins following <object>, the message shown to others in the room, and the actions to be taken by <object> when someone begins following it, respectively. The name of the person following <object> is automatically prepended to the @ofollow message.
 
 See also: follow, unfollow, @unfollow, followers(), ACTION LISTS, VERBS
@@ -260,7 +260,7 @@ See also: follow, unfollow, @unfollow, followers(), ACTION LISTS, VERBS
   @unfollow <object>[=<message>]
   @ounfollow <object>[=<message>]
   @aunfollow <object>[=<action list>]
-  
+
   Sets the message shown to someone who stops following <object>, the message shown to others in the room, and the actions to be taken by <object> when someone stops following it, respectively. The name of the person stopping following <object> is automatically prepended to the @ounfollow message.
 
 See also: follow, unfollow, @follow, followers(), ACTION LISTS, VERBS
@@ -272,7 +272,7 @@ See also: follow, unfollow, @follow, followers(), ACTION LISTS, VERBS
   @aahear <object>[=<action list>]
 
   Sets the actions to be taken after the object's @listen is matched. @ahear will only be triggered by sound made by other objects, and @amhear is only triggered by sound made by <object> itself. @aahear will be triggered by all matching sound, regardless of the source.
-  
+
 See also: @listen, LISTENING, ACTION LISTS
 & @leave
 & @oleave
@@ -282,9 +282,9 @@ See also: @listen, LISTENING, ACTION LISTS
   @oleave <object>[=<message>]
   @oxleave <object>[=<message>]
   @aleave <object>[=<action list>]
-  
+
   These attributes contain the message shown to anyone leaving <object>, the message shown to others inside <object> when someone leaves it, the message shown to others in <object>'s location when someone leaves it, and the actions to be taken by <object> when someone leaves it, respectively.
-  
+
   The leaver's new location is passed in %0, if <object> has permission to see it there.
 
 See also: leave, @oxleave, @lfail, ACTION LISTS, VERBS
@@ -296,22 +296,22 @@ See also: leave, @oxleave, @lfail, ACTION LISTS, VERBS
   @alfail <object>[=<action list>]
 
   These attributes contain the message shown to objects who try to leave <object> and fail, the message shown to others inside <object> when someone fails to leave, and the actions to be taken by <object> when someone attempts to leave it and fails.
-  
+
   Such a failure usually occurs because <object> is set NO_LEAVE, or because the person trying to leave does not pass <object>'s @lock/leave.
 
 See also: leave, @leave, NO_LEAVE, locktypes, ACTION LISTS, VERBS
 & @alias
   @alias <player>[=<name1>[;<name2>[;...;<nameN>]]]
   @alias <object>[=<string>]
- 
+
   For players and exits, the ALIAS attribute has special meaning: it contains a list of aliases (separated by semicolons) which can be used instead of its name to refer to the player or exit.
-  
+
   Players can only have a limited number of aliases; the number is controlled by the 'max_aliases' @config option. The same rules which apply to player names also apply to aliases, and you cannot use another player's name as your alias (though you can include your own name in your aliases, and can change your name to one of your aliases).
-  
+
   If the 'page_aliases' @config option is on, the first alias in the list is shown along with the player's name when they page others.
-  
+
   Exit aliases used to be a part of their name, though all newly created exits use @alias instead.
- 
+
   For other types of object, @alias has no special meaning.
 
 See also: @name, alias(), fullalias()
@@ -323,7 +323,7 @@ See also: @name, alias(), fullalias()
   @omove <object>[=<message>]
   @oxmove <object>[=<message>]
   @amove <object>[=<action list>]
-  
+
   These attributes contain the message shown to <object> immediately after it moves, the message shown to others in the room <object> moves into, the message shown to objects in the location <object> leaves, and the actions to be taken when <object> moves, respectively. Please note that long @omoves are frequently found annoying.
 
   The <object>'s new location is in %0 and the old location it moved from in %1.
@@ -342,9 +342,9 @@ See also: goto, @oxmove, ACTION LISTS, VERBS
   @oenter <object>[=<message>]
   @oxenter <object>[=<message>]
   @aenter <object>[=<action list>]
-  
+
   These attributes contain the messages shown to someone who enters <object>, the message shown to others inside <object> when someone enters it, the message shown to those in <object>'s location when someone enters it, and the actions to be taken by <object> when someone enters it, respectively.
-  
+
   The old location of the entering object is passed in %0, if <object> had permission to see it there.
 
   Example:
@@ -352,7 +352,7 @@ See also: goto, @oxmove, ACTION LISTS, VERBS
     > @oenter Sofa=sits with you on the sofa.
     > @oxenter Sofa=sits down on the sofa. It looks comfy.
     > @aenter Sofa=@pemit/silent owner(me)=%n sat down on [name(me)]!
-    
+
 See also: enter, @ealias, leave, ACTION LISTS, VERBS
 & @apayment
 & @payment
@@ -360,7 +360,7 @@ See also: enter, @ealias, leave, ACTION LISTS, VERBS
   @payment <object>[=<message>]
   @opayment <object>[=<message>]
   @apayment <object>[=<action list>]
-  
+
   These attributes contain the messages shown to someone who pays <object> pennies with the "give" command, the message shown to others when someone pays <object>, and the actions to be taken by <object> when it's paid. Each attribute is passed the number of pennies paid as %0.
 
   Example:
@@ -379,19 +379,19 @@ See also: give, @cost, buy, MONEY, ACTION LISTS, VERBS
   @atport <object>[=<action list>]
 
   These attributes contain the message shown to <object> when it is teleported, the message shown to others in the room <object> is teleported to, the message shown to others in the room <object> is teleported from, and the actions to be taken by <object> when it disappears, respectively.
-  
+
   In all of these attributes, %0 is the object which teleported <object>, and %1 is <object>'s old location.
-  
+
   Example:
   > @tport me=name(%0) has teleported you from [name(%1)] to [name(here)].
   > @otport me=appears in a puff of smoke.
   > @oxtport me=disappears in a puff of smoke.
-  
+
 See also: @teleport, ACTION LISTS, VERBS
 & @atrchown
 & @attrchown
   @atrchown <object>/<attribute>=<new owner>
-  
+
   This command changes the ownership of the attribute <attribute> on <object> to <new owner>. You can only @atrchown attributes which you can set. Wizards can @atrchown to any player, while mortals can only @atrchown attributes to themselves. Only players can own attributes; if <new owner> is not a player, <new owner>'s owner is used instead.
 
 See also: @atrlock, @chown, ATTRIBUTES, NON-STANDARD ATTRIBUTES
@@ -399,31 +399,31 @@ See also: @atrlock, @chown, ATTRIBUTES, NON-STANDARD ATTRIBUTES
 & @attrlock
   @atrlock <object>/<attribute>
   @atrlock <object>/<attribute=[on|off]
-  
+
   The first form of this command tells you whether or not the given attribute is locked (whether it has the "locked" attribute flag set).
-  
+
   The second form attempts to lock (for 'on') or unlock (for 'off') the given attribute. You automatically gain ownership of the attribute (as per @atrchown) when you lock it. Locked attributes cannot be altered by anyone but Wizards and the attribute's owner (though the owner may be unable to alter the attribute for other reasons, such as not controlling <object>). You must be able to set an attribute in order to lock it.
-  
+
   If you wish to lock an attribute without gaining ownership, you can set it "locked" with @set <obj>/<attr>=locked - be aware that you'll be unable to make any changes to the attribute after this, including unlocking it!
 
 See also: atrlock(), @atrchown, ATTRIBUTES, NON-STANDARD ATTRIBUTES
 & @asuccess
 & @success
 & @osuccess
-  @success <object>[=<message>] 
+  @success <object>[=<message>]
   @osuccess <object>[=<message>]
   @asuccess <object>[=<action list>]
-  
+
   For players and things, these attributes contain the message shown to someone who picks up <object> with the "get" command, the message shown to others when someone gets <object>, and the actions to be taken by <object> when someone gets it, respectively.
-  
+
   For exits, they contain the message shown to an object passing through the exit <object>, the message shown in the exit's source when someone passes through it, and the actions to be taken by the exit when someone passes through it, respectively.
-  
+
   In all cases, %0 is the dbref of the moving object's original location.
-  
+
   Example:
     > @success Door=You open the door and step inside.
     > @osuccess Door=opens the door and steps inside.
-    
+
     > @success Box=You pick up the box.
     > @osuccess Box=picks up the box.
 
@@ -432,29 +432,29 @@ See also: get, goto, @lock, SUCCESS, FAILURE, @odrop, ACTION LISTS, VERBS
   @attribute <attrib>
 
   The @attribute command displays and modifies the MUSH's standard attributes (see "@list/attribs" for a list of them).
-  
+
   Since 1.8.5p1, changes to the attribute table are saved across reboots and shutdowns, and don't need to be placed in an @startup.
 
   The first form of the command displays the full name of the attribute <attrib>, along with the its attribute flags, and the dbref of the object which added it to the attribute table.
-  
+
   Continued in 'help @attribute2'.
 & @attribute2
   @attribute/access[/retroactive] <attrib>=<flag list>
   @attribute/delete <attrib>
   @attribute/rename <attrib>=<new name>
   @attribute/decompile[/retroactive] [<pattern>]
-  
+
   @attribute/access adds <attrib> as a new standard attribute, with the default attribute flags <flag list>. If <attrib> is already a standard attribute, this command modifies its default attribute flags. Use "none" for <flag list> if you don't want any default attribute flags.
-  
+
   If the /retroactive switch is given with /access, all existing copies of the attribute will be @atrchown'd to the player running the command, and will have its flags changed to <flag list>.
-  
+
   @attribute/delete removes a standard attribute from the table.
-  @attribute/rename renames a standard attribute. 
-  
+  @attribute/rename renames a standard attribute.
+
   Only Wizards can modify the attribute table.
-  
+
   @attribute/decompile prints out a list of @attribute/access commands needed to recreate the attribute table on another MUSH. If /retroactive is given, that switch will be included in the output. If <pattern> is given, only attributes matching <pattern> are decompiled.
-  
+
   Continued in 'help @attribute3'.
 & @attribute3
   @attribute/limit <attrib>=<regexp pattern>
@@ -478,24 +478,24 @@ See also: ATTRIBUTES, attribute flags, @set, @atrchown,
   @use <object>[=<message>]
   @ouse <object>[=<message>]
   @ause <object>[=<action list>]
-  
+
   These attributes contain the message shown to someone who successfully uses <object>, the message shown to others when someone uses <object>, and the actions to be taken by <object> when it is used, respectively.
-  
+
   Note that, if <object> has a CHARGES attribute set and it does not contain a number greater than 0, the RUNOUT attribute is triggered instead of the AUSE attribute. See 'help @charges' for more information.
-  
+
   Example:
     > @use Jack-In-The-Box=You wind the handle.
     > @ouse Jack-In-The-Box=winds the handle.
     > @ause Jack-In-The-Box=@wait 3=POSE pops up with a bang!
     > use Jack-In-The-Box
-    
+
 See also: use, @charges, @runout, ACTION LISTS, VERBS
 & @away
   @away <player>[=<message>]
 
   If <message> evaluates to something non-null, it will be shown to anyone who pages <player> when she is not connected.
-  
-  Example: 
+
+  Example:
     > @away me=I'm not here, please send me @mail instead.
 
 See also: @idle, @haven
@@ -505,9 +505,9 @@ See also: @idle, @haven
   @boot/me
 
   The first form of this command disconnects all of <player>'s connections from the game.
-  
+
   The /port switch disconnects a particular descriptor (as shown under "Des" in the Wizard WHO, returned by lports() and ports(), etc).
-  
+
   If the /silent switch is given, the message telling <player> he was booted is suppressed.
 
   The /me switch boots all descriptors for the player using the command which have been idle for over 1 minute. Players can use this command to terminate hung connections.
@@ -521,7 +521,7 @@ See also: QUIT, LOGOUT
   @assert[/queued] <boolean>[=<action list>]
 
   @break stops the execution of further commands in the current action list if <boolean> is a true value. It doesn't affect new queue entries made by previous commands in the action list. It can be useful for doing error checking without having to nest @switches.
-  
+
   If <action list> is given, it is executed instead of the rest of the commands in the current action list. By default, <action list> is run immediately, replacing the rest of the action list @break was called in. If the /queued switch is given, <action list> will instead be queued to be run later. @break also accepts an /inline switch, for Rhost compatability; this switch does nothing on PennMUSH.
 
   @assert does the inverse: it stops execution if <boolean> evaluates to false.
@@ -535,7 +535,7 @@ See also: ACTION LISTS, QUEUE, BOOLEAN VALUES, @switch, @if
   > testme 0
   You try a test
   But you're too low!
-  
+
   > testme 10
   You try a test
   And you succeed!
@@ -550,15 +550,15 @@ See also: ACTION LISTS, QUEUE, BOOLEAN VALUES, @switch, @if
   @runout <object>[=<action list>]
 
   These attributes can limit how many times an object can be successfully "use"d. When you "use" an object with a CHARGES attribute set, the object's AUSE attribute is only triggered if CHARGES is a positive integer. When CHARGES is less than 1 (or not a number), the object's RUNOUT attribute is triggered instead.
-  
+
   When the CHARGES attribute is present and AUSE is triggered, the value of the CHARGES attribute is automatically decreased by 1. When no CHARGES attribute is set, AUSE is always triggered.
-  
+
   See 'help charges2' for an example.
 
 See also: use, @ause, ACTION LISTS
 & charges2
 & runout2
-  
+
   Example:
     > @create Revolver
     > @use Revolver=You pull the trigger.
@@ -566,15 +566,15 @@ See also: use, @ause, ACTION LISTS
     > @charges Revolver=6
     > @ause Revolver=POSE fires into the air.
     > @runout Revolver=POSE clicks, but is out of bullets.
-    
+
     > use revolver
     You pull the trigger.
     Revolver fires into the air.
     > ex revolver/charges
     CHARGES [#6$]: 5
-    
+
   The next 5 "use revolver"s work the same way, decrementing CHARGES each time.
-  
+
     > ex revolver/charges
     CHARGES [#6$]: 0
     > use revolver
@@ -589,7 +589,7 @@ See also: use, @ause, ACTION LISTS
   Changes the ownership of <object> to <player>. You can chown things, rooms or exits. Players can't be @chown'd - they always own themselves. To chown a thing, you have to be carrying it. If you do not own an object, you can only chown it if it has the CHOWN_OK flag and you pass its @lock/chown. If you're not a Wizard, you can only @chown objects to yourself or a Zone Master whose zone-lock you pass.
 
   Normally, @chown'ing an object clears privileged flags and powers, and sets the object halt. Wizards can use @chown/preserve to avoid this. Doing this to an active object with queued commands is not recommended, and may have strange and insecure effects.
-  
+
   If /<attribute> is specified, it acts as an alias for @atrchown; see 'help @atrchown' for details.
 
   Examples:
@@ -601,14 +601,14 @@ See also: CHOWN_OK, Zone Masters, @chownall, owner(), @atrchown
   @chownall[/preserve][/<types>] <player>[=<new owner>]
 
   This command @chowns all objects currently owned by <player> to the player <new owner>, or to the person running the command if no <new owner> is given. All the objects will have privileged flags and powers cleared, and be set halt, unless the /preserve switch is given.
-  
+
   If one or more of /things, /rooms or /exits are provided, only objects of the given types are chowned. Otherwise, all objects are chowned.
-  
+
   This command can only be used by Wizards.
 
 See also: @chown
 & @chzone
-  @chzone[/preserve] <object>=<zone> 
+  @chzone[/preserve] <object>=<zone>
   @chzone <object>=none
 
   The first form of this command changes the zone of <object> to <zone>. This puts the object on that zone and may (if the zone_control_zmp_only @config option is off) allow anyone who passes the Zone @lock of <zone> to control <object>. Any kind of object can be @chzoned, and any kind of object can be used as a zone.
@@ -616,8 +616,8 @@ See also: @chown
   The second form of this command removes <object> from its current zone, leaving it unzoned.
 
   If a player is @chzoned, any objects he creates from that point on will automatically be on the same zone. Objects the player already owns are not affected.
-  
-  You must control <object>, and either control <zone> or pass its @lock/chzone. 
+
+  You must control <object>, and either control <zone> or pass its @lock/chzone.
 
   Continued in 'help @chzone2'.
 & @chzone2
@@ -632,20 +632,20 @@ See also: ZONES, @chzoneall, zone()
   @chzoneall[/preserve] <player>=<zone object>
 
   Changes the zone of all objects owned by <player> to <zone object>. If <zone object> is "none", the zone is reset to NOTHING. Only wizards may use this command.
-  
+
 See also: @chzone, ZONES
 & @clone
   @clone <object>[=<new name>[, <dbref>]]
   @clone/preserve <object>[=<new name>[, <dbref>]]
 
   This command creates a copy of <object>. The clone will have the same name as the original unless a <new name> is given for it. You can only clone things, rooms and exits, not players. You must control <object>. The new object will be owned by the player who performs the @clone, not the owner of the original <object>.
-  
+
   When cloning things and exits, the clone will be placed in your current location, not the location of <object>. When cloning rooms, the exits and contents in the room are not cloned as well.
 
   The cloned object will have the same modification time as the original object, to make tracking revisions easier, but will have a different creation time.
-  
+
   Normally, the Wizard and Royalty flags, @powers and @warnings are stripped from the cloned object, but Wizards may use the /preserve flag to prevent this.
-  
+
   The clone will normally be created with the first available dbref, but Wizards and objects with the pick_dbref power may specify the <dbref> of a garbage object to use that instead.
 
   To clone a room and all its exits, use code like:
@@ -663,7 +663,7 @@ See also: @create, clone(), create(), @cpattr
   @command can be used for adding new built-in commands, altering the way a built-in command works, and displaying information about how commands currently work.
 
   With no switches, @command shows all sorts of interesting information about how a command is parsed. Any player can use @command with no switch, while the switches are Wizard-only.
-  
+
   The /alias switch creates an alias for <command>, allowing players to type <alias> to run <command>. The /clone switch creates a separate copy of <command>, which works the same initially but can be restricted, @hooked, etc, separately.
 
   @command/restrict can be used to restrict who can use <command>. See 'help restrict' for more information.
@@ -717,16 +717,16 @@ See also: @hook, RESTRICT, EVALUATION ORDER
   @comment <object>[=<comment>]
 
   This is a wizard-only command which sets a COMMENT attribute on <object>. The attribute can only be seen by those with the See_All power.
-  
+
 See also: @@, @@()
 & @config
   @config
   @config [<category>|<option>]
   @config/set <option>=<value>
   @config/save <option>=<value>
-  
+
   With no arguments, @config lists the categories of configuration options for the MUSH. With an argument, @config lists the options in the given <category>, or shows the current value of the given <option>.
-  
+
   The wizard-only /set switch changes the value of <option> to <value>. This change does not last across reboots. God can also use the /save switch, which attempts to save the new <value> in the mush.cnf configuration file, as well as changing it in-game.
 
   For information about parameters, see 'help @config parameters'
@@ -734,7 +734,7 @@ See also: @@, @@()
   @conformat <object>[=<format>]
 
   When set, the CONFORMAT attribute is evaluated when <object> is looked at, and the result is displayed instead of the usual "Contents:" (for rooms) or "Carrying:" (for players and things) list of contents.
-  
+
   The dbrefs of the objects which would appear in the normal contents list are passed to the attribute as %0 (you can use lcon(me) for a full contents list). A list of the names of these objects as they would appear in the default contents list is passed as %1, |-delimited.
 
   Q-registers (set via setq() and similar functions) are inherited from the @descformat, and passed on to the @exitformat.
@@ -742,7 +742,7 @@ See also: @@, @@()
   Examples:
     Show the normal contents list, but in upper-case:
     > @conformat here=edit(ucstr(%1), |, %r)
-    
+
     Show just the object names (with no ansi) in a table:
     > @conformat here=table(iter(%0, name(%i0), %b, |), 20, width(%#), |)
 
@@ -761,17 +761,17 @@ See also: look, @exitformat, @nameformat, @descformat, @invformat,
   When including attribute contents, @include ignores any ^...: or $...: at the start, so the CHECKS attribute above could also be written like this, to allow for "unit testing":
 
     &CHECKS me=$testchk *: @assert [orflags(%#,Wr)]; @break [gt(words(lwho()),%0)]
- 
-  The including environment (%0-%9) is available to the included actions. If arguments are provided to @include, they are substituted for the environment's %0, %1, etc. while the included action list is running. The environment is then restored after the @include. 
-  
+
+  The including environment (%0-%9) is available to the included actions. If arguments are provided to @include, they are substituted for the environment's %0, %1, etc. while the included action list is running. The environment is then restored after the @include.
+
   Continued in 'help @include2'.
 & @include2
-  
+
   @include takes the following switches to alter its behaviour:
   /nobreak:   Prevents an @break/@assert in the included attribute from breaking the including action list.
   /localize:  Saves all q-registers before including the attribute, and restores them after including the attribute.
   /clearregs: Clears all q-registers before including the attribute.
-  
+
 See also: @trigger, ufun(), @break
 & @invformat
   @invformat <object>[=<format>]
@@ -782,17 +782,17 @@ See also: @trigger, ufun(), @break
     > @invformat me=You're holding: [itemize(iter(%0, name(%i0), %b, |), |)]
     > inventory
     You're holding: Red Ball, Pickle, and Piano
- 
+
 See also: inventory, @conformat, @exitformat, @nameformat, @descformat, @idescformat
 & @descformat
   @descformat <object>[=<format>]
 
   When set, this attribute is evaluated and displayed instead of <object>'s @describe, when someone looks at <object>. The evaluated @describe, which would be shown if no @descformat were set, is passed to the @descformt as %0; use v(describe) to get the unevaluted description.
-  
+
   This is primarily useful for room parents, to enforce a consistent look for all rooms without having to apply formatting to ever @describe. Note that this object is only used with @describe - to format the @idescribe, use @idescformat.
-  
+
   Q-registers (set via setq() and similar functions) are inherited from the @nameformat, and passed on to the @conformat.
-  
+
   Example:
     > @descformat Room Parent=repeat(=, width(%#))%r%0[repeat(=, width(%#))]
 
@@ -801,11 +801,11 @@ See also: look, @exitformat, @nameformat, @conformat, @idescformat, @invformat
   @idescformat <object>[=<format>]
 
   When set, this attribute is evaluated and displayed instead of <object>'s @idescribe, when someone looks at <object> while inside it. The evaluated @idescribe, which would be shown if no @idescformat were set, is passed to the @idescformt as %0; use v(idescribe) to get the unevaluted description.
-  
+
   Note that this attribute is only used when an @idescribe is set. When no @idescribe is set, the @descformat (and @describe) attributes are used, even when someone "look"s inside <object>.
 
   This is useful for things like object parents that enforce a consistent "look" for each object's @idescribe, without having to place formatting into every @idescribe.
-  
+
   Q-registers (set via setq() and similar functions) are inherited from the @nameformat, and passed on to the @conformat.
 
   Example:
@@ -816,7 +816,7 @@ See also: look, @exitformat, @nameformat, @conformat, @descformat, @invformat
   @nameaccent <object>[=<accent template>]
 
   When this attribute holds an accent template that is the same length as <object>'s @name, it is used to change the object's name in some situations (how it shows up in speech, look, and a few other commands). This allows for accented names without having to use the accented characters directly in a name, which can make it harder for people to type.
-  
+
   The <accent template> is explained in 'help accents'.
 
   If a container has both a @nameaccent and a @nameformat, the @nameformat is used.
@@ -826,11 +826,11 @@ See also: accent(), @nameformat, accname(), stripaccents(), iname()
   @nameformat <object>[=<format>]
 
   When set, this attribute is evaluated and displayed in place of <object>'s name, when objects inside <object> "look". The room's dbref is passed as %0, and the default-formatted name (as it would be displayed with no @nameformat set) is passed as %1.
-  
+
   @nameformat is not used when people who are outside the object look at it.
-  
+
   Q-registers (set via setq() and similar functions) are passed on from the nameformat to the other @*format attributes used for formatting "look" output. Use localize() if you don't want this behaviour.
-  
+
   Example:
     Show the room's zone after its name.
     > @nameformat here = %1 [if(zone(%0),<[name(zone(%0))]>)]
@@ -838,16 +838,16 @@ See also: accent(), @nameformat, accname(), stripaccents(), iname()
 See also: look, @exitformat, @conformat, @descformat, @nameaccent, @invformat, @idescformat, iname()
 & @cost
   @cost <object>[=<amount>]
-  
+
   The COST attribute contains the number of pennies that must be given to <object> to trigger its @pay/@opay/@apay attributes. If less than this amount is given, the money will be refused, and if more is given, the difference is refunded.
-  
+
   This attribute is evaluated, with the amount being given passed as %0. If the attribute returns a number less than 0, the money will be refused. Non-players must have this attribute set in order to receive pennies. Players who don't have a COST always accept the amount of pennies given.
 
   Example:
     > @cost Exit Machine=10
-    > @apay Exit Machine=@open %n-exit 
+    > @apay Exit Machine=@open %n-exit
     > @pay Exit Machine=Your exit has been created.
- 
+
     > give Exit Machine=10
     Your exit has been created.
     (The exit will also have been opened by the machine.)
@@ -860,11 +860,11 @@ See also: give, MONEY, @pay, money(), buy
 & @mvattr
   @cpattr[/noflagcopy] <obj>/<attr>=<obj1>[/<attr1>][, ..., <objN>[/<attrN>]]
   @mvattr[/noflagcopy] <obj>/<attr>=<obj1>[/<attr1>][, ..., <objN>[/<attrN>]]
-  
+
   @cpattr copies the <attr> attribute from <obj> to <obj1> (and any other objects given). By default, the new attributes will have the same name as the original, but you can specify a different name to be used on each object if you wish.
-  
+
   @mvattr works the same, but also attempts to remove the original attribute after copying it.
-  
+
   Attribute flags are copied as well, unless the /noflagcopy switch is given. This is recommended when copying from a non-standard attribute to a standard one.
 
   Example:
@@ -881,13 +881,13 @@ See also: ATTRIBUTES, NON-STANDARD ATTRIBUTES, @set
   This command creates a new thing called <name>. Creating an object costs a certain number of pennies (see '@config object_cost'); you can specify a higher cost if you wish. This cost is refunded to you when the object is destroyed.
 
   Some MUSHes choose to limit the number of objects you can create by setting a quota.
-  
+
   Wizards and objects with the pick_dbref power can also specify the <dbref> of a garbage object to use when creating the object. Otherwise, the object is given the next available dbref.
- 
+
 See also: give, @quota, MONEY, @clone, create(), @dig, @open, @pcreate
 & @dbck
   @dbck
-  
+
   This is a wizard only command. It forces the database to perform a series of internal cleanup and consistency checks that normally run approximately every 10 minutes:
 
   1. For every object, make sure its location, home, next, contents, parent, and zone fields are valid objects.
@@ -928,7 +928,7 @@ See also: give, @quota, MONEY, @clone, create(), @dig, @open, @pcreate
     Don't output commands to set attribute flags if those flags are the defaults for that attribute on that MUSH.
   @decompile/tf
     Explained in 'help @decompile3'.
-  
+
   Continued in 'help @decompile3'.
 & @decompile3
 
@@ -936,11 +936,11 @@ See also: give, @quota, MONEY, @clone, create(), @dig, @open, @pcreate
 
   The /tf works the same as if you'd typed:
     @decompile/db <obj>[/<attrs>]=[default(me/TFPREFIX, FugueEdit >%b)]
-    
+
   with the exception that @decompile/tf does not include commands for setting attribute flags. If you have a TFPREFIX attribute set, the (unevaluated) contents of that attribute is used as the prefix. Otherwise, the string "FugueEdit > " is used. It's useful for automatically copying @decompile output into your client to alter. It is highly recommended that you set a TFPREFIX attribute, to prevent others from maliciously placing code in your client's command line.
 
   To set up @decompile/tf:
-  
+
     In TinyFugue:
       /def -ag -mglob -p100 -t"FugueEdit > *" fe = /grab %-2
 
@@ -956,7 +956,7 @@ See also: CLIENTS, ATTRIBUTES, WILDCARDS, MUSHCODE
   This command sets the description of the object, which will be seen whenever something looks at the object with the 'look' command. Every object should have a description, even if just a short one describing its purpose. When looking at a thing, player or exit which has no description, you will see the message "You see nothing special.". A room with no desc set shows nothing.
 
   The description can be formatted using the @descformat attribute. This is particularly useful for @parents and ancestors.
-  
+
   When inside a thing or player, you will see its @idescribe instead, if one is set.
 
   @describe can be abbreviated as @desc.
@@ -969,7 +969,7 @@ See also: look, @adescribe, @idescribe, @descformat
   @nuke <object>
 
   The @destroy command marks <object> for destruction, or destroys <object> instantly if it was already marked for destruction. You must either control <object>, control its source or destination room (for exits), or it must be set DESTROY_OK and you must pass its @lock/destroy.
-  
+
   To destroy objects set SAFE, you must use @destroy/override or @nuke. If the really_safe @config option is on, even @nuke can't destroy SAFE objects, and you must clear the SAFE flag first.
 
   @recycle is an alias for @destroy. Some MUSHes disable @destroy and only use @recycle, to avoid players mistyping. @nuke is an alias for @destroy/override.
@@ -979,9 +979,9 @@ See also: @undestroy, @create, @dig, @open, DESTROY_OK, SAFE
 & @destroy2
 & DESTRUCTION
   When an object is marked for destruction, the GOING flag is set on it and its @adestroy attribute is triggered (if the 'adestroy' @config option is true). If <object> is a room, all the exits in the room are marked for destruction as well. If <object> is a player, and the @config option destroy_possessions is on, everything he owns is marked for destruction as well. (If really_safe is also on, his SAFE objects are spared.)
-  
+
   The MUSH checks for GOING objects every ten minutes or so (see '@config purge_interval'); each one is set with the GOING_TWICE flag, and will be destroyed totally on the next cycle. You can save it from destruction during this period using the @undestroy command, or @destroy it again to destroy it instantly. The GOING and GOING_TWICE flags cannot be set or removed manually.
-  
+
   When an object is destroyed, any commands, @waits and semaphores it has queued are drained, and the object's owner has the quota for the object, and the initial cost of creating it, refunded. The OBJECT`DESTROY event is also queued.
 
   Players can only be @destroyed when they are not connected, and even then can only be destroyed by a Wizard player. If the destroy_possessions @config option is on, anything the player owns is @destroyed. If the really_safe option is also on, his SAFE possessions are spared. Any objects he owns which aren't destroyed are @chown'd to the Probate player (as per '@config probate_judge'), as are any @channels the player owned.
@@ -990,28 +990,28 @@ See also: SAFE, EVENTS
 & @undestroy
 & @unrecycle
   @undestroy <object>
-  
+
   When an object has been marked for destruction using @destroy, this command spares it from destruction, removing the GOING and GOING_TWICE flags. You must control <object>. <object>'s @startup is triggered when it is spared.
-  
+
   If <object>'s owner is marked for destruction, they will also be spared.
-  
+
   If <object> is a player and the 'destroy_possessions' @config option is on, all objects he owns will also be undestroyed. If <object> is a room, all exits in the room will also be undestroyed. If <object> is an exit and its source room is marked for destruction, it will be undestroyed.
-  
+
   @unrecycle is an alias for @undestroy.
-  
+
 See also: @destroy, GOING, @startup
 & @dig
   @dig[/teleport] <room name>[=<exit to>, <exit from>, <room dbref>, <to dbref>, <from dbref>]
-  
+
   This command creates a new room named <room name>. Creating a room costs some pennies (see '@config room_cost' for exactly how many). If the /teleport switch is given, you will be teleported to the room after it's created, as per the @teleport command.
-  
+
   If <exit to> is given, the MUSH will automatically open an exit from your current location to the new room named <exit to>, if you have permission. You can also specify <exit from>, to create an exit from the new room back to your current location. Opening exists also costs pennies; see '@config exit_cost'. The exit names may contain multiple aliases, separated with semicolons, as per 'help @name'.
 
   Wizards and objects with the pick_dbref power can also specify the dbrefs of garbage objects to use when creating the room and the to and from exits.
-  
+
   See 'help @dig2' for examples.
 & @dig2
-  Examples: 
+  Examples:
     > @dig Kitchen
   This command will create a new room named 'Kitchen'. You will be informed what the dbref of this room is.
 
@@ -1026,19 +1026,19 @@ See also: @open, @link, EXITS, @create, DBREF, dig()
   @doing <object>[=<message>]
 
   With a <message> argument, this command sets <object>'s DOING attribute to <message>. The DOING attribute is only meaningful for players; the evaluated result is shown on the output of the normal MUSH WHO command, and on the login screen WHO.
-  
+
   With no <message> the attribute is cleared.
-  
+
   To change the message shown above player @doings in WHO, use @poll.
 
 See also: @poll, WHO, doing()
 & @dolist
   @dolist[/<switches>][/notify][/delimit <delim>] <list>=<action list>
-  
+
   @dolist queues the <action list> for execution once for each element in <list>. <list> is space-separated, unless the /delimit switch is given, in which case it is a <delim>-separated list.
-  
+
   The %i0 substitution, or the function itext(0), can be used in the <action list> to get the current element of the <list>, and the inum(0) function returns the position of the current element. ilev() returns the nesting depth of @dolists. The %iL substitution returns the itext() for the outermost @dolist, and is equivilent to itext(ilev()).
-  
+
   For backwards compatability, the string "##" is also replaced with the current element of the list, and "#@" the current position. However, these replacements occur BEFORE evaluation, which means that they always return the values for the outermost @dolist, and are thus unsuitable for nesting. It also makes them unsafe for use on user-input or strings which may contain special characters; using the %i* sub or itext() instead is very strongly recommended.
 
   Continued in 'help @dolist2'.
@@ -1052,7 +1052,7 @@ See also: @poll, WHO, doing()
    /nobreak:  @breaks in <action list> do not effect to the calling action list
    /localize: q-registers are saved before each <action> is run, and restored after it completes
    /clearreg: q-registers are all reset before each <action> is run. Most useful when used in combination with /localize.
-              
+
   @dolist/inplace is an alias for @dolist/inline/nobreak/localize.
 
   See 'help @dolist3' for examples.
@@ -1074,7 +1074,7 @@ See also: iter(), itext(), map(), @notify, SEMAPHORES, ACTION LISTS
    You say, "c is 3"
    Notified.
    You say, "Done"
-   
+
    > @dolist a b c=@dolist 1 2 3=say %iL/%i0
    You say, "a/1"
    You say, "a/2"
@@ -1088,7 +1088,7 @@ See also: iter(), itext(), map(), @notify, SEMAPHORES, ACTION LISTS
 
 & @drain
   @drain[/any][/all] <object>[/<attribute>][=<number>]
-  
+
   This command discards commands waiting on a semaphore without executing them. (For non-semaphore queues, use @halt or @halt/pid.)
 
   If the /any switch is given, then all semaphores associated with <object> are @drained. Otherwise, only the specified semaphore attribute (or SEMAPHORE if no <attribute> is specified) is @drained.
@@ -1101,15 +1101,15 @@ See also: SEMAPHORES, @wait, @notify, @halt
 & @dump
   @dump
   @dump[/paranoid|/debug|/nofork] [<check interval>]
- 
+
   This is a wizard-only command which saves a copy of the database from memory into the outdb file on disk. The MUSH saves the game automatically at a regular interval, controlled by the "dump_interval" @config option.
- 
+
   If the /paranoid switch is given, the game performs additional consistency checking which corrects possible data corruption in the copy of the db written to disk. If a check interval is specified, the game writes confirmation of the dump to the checkpoint log file every <interval> objects. If no interval is specified, it is taken to be the size of the database, divided by 5.
-  
+
   @dump/debug is the same as @dump/paranoid, but also attempts to fix any errors found in the running (in-memory) copy of the database. In order to do this safely, the dump will be a non-forking dump, even if the MUSH is configured to do forking dumps (see "@config forking_dump").
 
   @dump/nofork does a normal, always non-forking dump.
-  
+
   These switches should ONLY be used if a normal @dump is not being done correctly. They should generally only be done by wizards with access to the account on which the MUSH is running, since others will not have access to the checkpoint log file.
 
 See also: @shutdown
@@ -1117,11 +1117,11 @@ See also: @shutdown
 & @lalias
   @ealias <object>[=<enter alias1>[; ... ; <enter aliasN>]]
   @lalias <object>[=<leave alias1>[; ... ; <leave aliasN>]]
-  
+
   These attributes contain lists of "enter aliases" and "leave aliases" for <object> - any of the aliases can be used in place of "enter <object>" and "leave <object>" to enter/leave the object.
-  
+
   These attributes only have meaning for players and things (as rooms/exits cannot be "enter"ed) - the aliases for exits are stored in @alias.
-  
+
   Example:
     > @ealias Chair=Sit down;sit
     > @lalias Chair=Stand up;stand
@@ -1129,50 +1129,50 @@ See also: @shutdown
 See also: enter, leave, goto, ENTER_OK
 & @edit
 & @gedit
-  @edit[/first][/check][/quiet] <object>/<attributes>=<search>, <replace> 
+  @edit[/first][/check][/quiet] <object>/<attributes>=<search>, <replace>
   @edit[/check][/quiet] <object>/<attributes>=$, <string to append>
   @edit[/check][/quiet] <object>/<attributes>=^, <string to prepend>
 
   This command allows you to edit the contents of attributes, without having to retype the entire attribute.
-  
+
   All the attributes on <object> whose names match the wildcard pattern <attributes> will be searched for the string <search>, and each occurrence of it will be replaced with the string <replace>.
-  
+
   If <search> is "$", then <replace> will be added to the end of the attributes. When <search> is "^", <replace> will be added to the beginning of the attributes. (If you need to replace a single $ or ^, consider using @edit/regexp (see help @edit2) or the edit() function.)
-  
+
   If the /first switch is given, only the first occurrence of <search> in each attribute is replaced. If the /check switch is given, the attributes are not altered, you'll just be shown what would be changed (with the changes ansi-highlighted).
-  
+
   If the /quiet switch is given, you won't be shown the modified text, you'll just be told how many of the matching attributes were/weren't edited. Useful when edited a lot of large/spammy attributes.
-  
+
   <search> and <replace> are not evaluated, so you don't need to escape special characters. If either contains commas, however, you may need to wrap the string in {curly braces}.
-  
+
   Continued in 'help @edit2'.
 & @edit2
   @edit/regexp[/all][/nocase][/check][/quiet] <object>/<attributes>=<regexp>,<replace>
 
   When the /regexp switch is given, @edit performs a regular expression replacement, similar to the regedit() function. Normally, only the first match per attribute will be replaced; if the /all switch is given, all possible matches in each attribute are replaced (as per regeditall()).
-  
+
   Regexp matches are case-sensitive by default, but the /nocase switch can be given to make them case-insensitive (as per regediti()/regeditalli()).
-  
+
   The /check and /quiet switches work the same as for non-regexp @edits.
-  
+
   Note that, unlike normal @edits, the <replace> for an @edit/regexp WILL be evaluated, once for each replacement made, with the $0 token being replaced with the overall matching text, $1 with the first subexpression, and so on. Named subexpressions are also possible via $<name>.
-  
+
   Example:
   > &foo me=Block of text/Wed Feb 22 22:54:02 2012/#10010
   > @edit/regexp me/foo=^(.+)/([^/]+)/(#[0-9]+(?::[0-9]+)?)$, ucstr($1) -- [convtime($2)] -- [name($3)]
   FOO - Set: BLOCK OF TEXT -- 1329951242 -- Minion
-  
+
   Replace a literal '^' with 'v'
   > @edit/regexp me/bar=\^, v
-  
+
 See also: edit(), regedit(), ATTRIBUTES, WILDCARDS
 & @elock
 & @eunlock
   @elock <object>[=<key>]
   @eunlock <object>
-  
+
   @elock sets the Enter @lock for <object> to <key>, or clears the the lock if no <key. is given. @eunlock removes the Enter @lock for <object>.
-  
+
   @elock and @eunlock are deprecated and uses of them should be replaced by
     @lock/enter <object>[=<key>]
   and
@@ -1208,7 +1208,7 @@ See also: @config
   @zenter <object>[=<message>]
   @ozenter <object>[=<message>]
   @azenter <object>[=<action list>]
-  
+
   These attributes set the message shown to a player when he enters the zone <object>, the message shown to others in the room the player enters when he enters the zone, and the action to be taken by the zone <object> when the player moves into an area zoned to it.
 
   Entry into a new zone is said to occur when a player goes from a room not in the zone to a room in the zone. "Room" in this context means the player's absolute room (outermost container), so entering and leaving unzoned objects within a zoned room doesn't trigger these.
@@ -1222,7 +1222,7 @@ See also: @zleave, ZONES, @zemit, zwho(), VERBS
   @zleave <object>[=<message>]
   @ozleave <object>[=<message>]
   @azleave <object>[=<action list>]
-  
+
   These attributes set the message shown to a player when he leaves the zone <object>, the message shown to others in the room he left when leaving the zone, and the actions to be taken by <object> with a player leaves an area zoned to it.
 
   Leaving a zone is said to occur when a player goes from a room in the zone to a room not in the zone. "Room" in this context means the player's absolute room (outermost container), so entering and leaving unzoned objects within a zoned room doesn't trigger these.
@@ -1232,17 +1232,17 @@ See also: @zleave, ZONES, @zemit, zwho(), VERBS
 See also: @zenter, ZONES, @zemit, zwho(), VERBS
 & @entrances
   @entrances[/<switch>] [<object>][=<begin>[, <end>]]
-  
+
   This command will show you all objects linked to <object>. If you don't specify an <object>, your current location is used. You can limit the range of the dbrefs searched by specifying <begin> and <end>.
-  
+
   You can use any combination of switches to limit the types of objects:
     /exits       show only exits linked to <object>
     /things      show only things which have their homes in <object>
     /players     show only players who have their homes in <object>
     /rooms       show only rooms which have a drop-to of <object>
-    
+
   If you control <object>, or have the Search or See_All powers, all objects linked to <object> are listed. Otherwise, only objects which you can examine will be shown.
-    
+
 See also: @link, @search, entrances()
 & @exitformat
   @exitformat <object>[=<format>]
@@ -1274,9 +1274,9 @@ See also: TRANSPARENT, @conformat, @nameformat, @descformat
 See also: urlencode(), urldecode()
 & @firstexit
   @firstexit <exit1>[, ... , <exitN>]
-  
+
   Normally, exits appear in a room's Obvious exits list in the order they were created, most recent first. You can use this command to rearrange them. @firstexit moves each exit, in the order given, to the top of the Obvious exits list for its source room. You must control the room.
-  
+
   Example:
     > @dig/teleport Test Room
     > @open Two ; @open Three ; @open One
@@ -1293,25 +1293,25 @@ See also: urlencode(), urldecode()
 See also: EXITS, @open, @link
 & @filter
   @filter <object>[=<pattern1>[, <pattern2>[, ..., <patternN>]]
- 
+
   The filter attribute is used in conjunction with the AUDIBLE flag. When set, sound which matches any of the comma-separated list of wildcard patterns in this attribute is not propagated through the audible object.
-  
+
   @filter uses the type of matching described in HELP SWITCH WILDCARDS.
 
   If you need to use a comma in one of the patterns, put a \ before it, do not use {} curly braces.
 
   You can set the regexp flag on the filter attribute to use regular expressions instead of wildcard patterns, and can set the case flag to make the patterns case-sensitive.
-  
+
   Sounds are only forwarded if the speaker also passes <object>'s @lock/filter, which receives the sound heard as %0.
-  
+
   See 'help @filter2' for an example.
-  
+
 See also: AUDIBLE, @infilter, attribute flags, LISTENING, @forwardlist, @prefix, WILDCARDS
 & @filter2
 
-  Example: 
+  Example:
   An audible exit leads from the room where Wizard is standing to another room where the puppet "Wiztoy" is standing.
-  
+
     > @prefix exit=From inside,
     > :tests.
     Wizard tests.
@@ -1355,13 +1355,13 @@ See also: DEBUG, @forwardlist, @lock
 & @force
   @force[/noeval][/inline] <object>=<action list>
 
-  This command forces <object> to queue the given action list, as if the object had entered the action list itself. You must control <object> to @force it. @force is useful for manipulating puppets. 
+  This command forces <object> to queue the given action list, as if the object had entered the action list itself. You must control <object> to @force it. @force is useful for manipulating puppets.
 
   If /inline is given, <object> will run <action list> _now_, instead of being queued for execution later. By default, <action list> will be able to see/alter q-registers in the calling action list, and any @breaks in <action list> will also stop the calling action list. The following switches alter that behaviour:
    /nobreak:   @breaks in <action list> will not stop the calling action list.
    /localize:  q-registers will be saved before <action list> is run, and restored after.
    /clearregs: q-registers will all be reset before <action list> is run. You'll usually want to use /localize as well with this.
-               
+
   @force/inplace is an alias for @force/inline/nobreak/localize.
 
   @force can be abbreviated as
@@ -1373,7 +1373,7 @@ See also: DEBUG, @forwardlist, @lock
 
   Examples:
     > @create Lackey
-    Created: Object #103 
+    Created: Object #103
     > @force Lackey=go east
     Lackey goes east.
     Lackey has left.
@@ -1388,7 +1388,7 @@ See also: DEBUG, @forwardlist, @lock
 
   Examples:
     > @create Lackey
-    Created: Object #103 
+    Created: Object #103
     > &order me=$order *:say Lackey, %0 ; @force Lackey=%0 ; say Done?
     > order pose salutes!
     You say, "Lackey, pose salutes!"
@@ -1424,16 +1424,16 @@ See also: PUPPET, DBREF, objeval()
     /letter changes or removes a single-letter alias for an existing flag.
     /restrict changes flag permissions (see help @flag2)
     /type changes flag type(s) (see help @flag2)
-    /delete deletes a flag completely, removing it from all objects in the database and then removing it permanently from the flag table. It requires the exact flag name or alias to be used. Be very very careful with this. 
+    /delete deletes a flag completely, removing it from all objects in the database and then removing it permanently from the flag table. It requires the exact flag name or alias to be used. Be very very careful with this.
     /decompile prints out a list of @flag/add commands needed to recreate the flag table on another MUSH. If <pattern> is given, only flags whose names match that wildcard pattern are shown.
 
   See 'help @flag2' for information on @flag/add.
-  
+
 See also: FLAGS, @set, @power, flag permissions
 & @flag2
   @flag/add is used to add a new flag with the given name. Arguments other than the flag name are optional:
 
-  <letter> gives the flag's one-letter abbreviation, which must not conflict with the one-letter abbreviation of another flag that could be applied to the same object type(s). It defaults to none, which means it won't appear in a list of flag characters but can still be tested for with hasflag(), andlflags(), and orlflags(). 
+  <letter> gives the flag's one-letter abbreviation, which must not conflict with the one-letter abbreviation of another flag that could be applied to the same object type(s). It defaults to none, which means it won't appear in a list of flag characters but can still be tested for with hasflag(), andlflags(), and orlflags().
   <type> specifies the space-separated list of types to which the flag applies, and may be 'any' (the default) or one or more of 'room', 'thing', 'player', or 'exit'.
   <setperms> specifies the space-separated list of permissions for who can set and/or see the flag. See 'help flag permissions' for details. It defaults to 'any'
   <unsetperms> specifies the space-separated list of permissions for who can clear the flag on an object they control. It defaults to whatever <setperms> is given, or 'any'.
@@ -1450,11 +1450,11 @@ See also: FLAGS, @set, @power, flag permissions
   The following permissions can be used to specify whether <looker> can see the flag on an <object>, and are given along with the <setperms> in @flag/add. By default, anyone can see the flag:
 
    dark        <actor> must be Only God (#1) to see the flag on objects
-   mdark       <actor> must be WIZARD or ROYALTY 
+   mdark       <actor> must be WIZARD or ROYALTY
    odark       <actor> must own the <object> (or be WIZARD or ROYALTY)
 
   The following permissions control other behavior related to the flag:
-  
+
   log          Log when the flag is set or cleared. Only meaningful in <setperms>.
   event        Trigger the OBJECT`FLAG event when this flag is set or cleared. Only meaningful in <setperms>. See 'help events' for more information.
 & @function
@@ -1465,43 +1465,43 @@ See also: FLAGS, @set, @power, flag permissions
   @function/restrict[/builtin] <function name>=<restrictions>
   @function/alias <function name>=<alias>
   @function/clone <function name>=<clone>
-  
+
   When used without any arguments, this command lists all global user-defined functions. For wizards and others with the Functions power, it also lists the dbref number and attribute corresponding to the listed functions.
 
   When used with a function name, it displays some information about how that function is parsed, and how many arguments it takes.
-  
+
   <switch> can be one of:
   /disable, to disable a function.
   /enable, to re-enable it.
   /delete, to remove a user-defined or cloned function, or allow a built-in function to be overriden by a user-defined one.
   /restrict, to change the restriction flags on an existing function.
-  
+
   @function/alias creates an alias for the built-in function <function name> so that it can also be called as <alias>. @function/clone creates a new copy of <function name> named <clone>, which works the same initially but can be restricted separately. You cannot alias or clone @functions, or alias cloned functions.
 
   Otherwise, this command defines a global function with the name <function name>, which evaluates to <attribute> on <object>.
-  
+
   Continued in 'help @function2'.
 & @function2
   <object> can be anything that the player using the @function command controls (if safer_ufun is enabled) or can examine (if not). <function name> must be 30 characters or less.
 
   A function defined using @function works just like any of the normal MUSH functions, from the user's perspective. The functions are executed by the object, with its powers.
- 
+
   Functions defined via @function should follow the format used by UFUN() - %0 is the first argument passed, %1 is the second argument passed, and so forth. Optional third and fourth arguments to @function can be used to set a parser-enforced number of arguments for the function. If the maximum arguments is negative, any additional arguments are treated as part of the text of the last argument. Note that this behaviour is deprecated, and will be removed in the near future.
-  
+
   An optional fifth argument will set restriction flags.
 
   The /preserve switch, for MUX compability, does the same thing as the 'localize' restriction - treats the attribute that's evaluated as if it were called with ulocal() instead of u().
-  
+
   Example:
-  
+
     > &WORD_CONCAT #10=%0 %1
     > say u(#10/word_concat, foo, bar)
     You say, "foo bar"
-  
+
     > @function word_concat=#10, word_concat
     > say word_concat(foo,bar)
     You say, "foo bar"
- 
+
   Continued in 'help @function3'.
 & @function3
   Global user-defined functions are not automatically loaded when the game is restarted. In order to avoid objects which attempt to use functions that have not been loaded, a @startup containing @function commands should be set on a wizard object with as low a dbref number as possible; God (#1) is suggested for this use. You can also create functions from the alias.cnf file.
@@ -1511,7 +1511,7 @@ See also: FLAGS, @set, @power, flag permissions
     @startup #1=@dolist lattr(#100)=@function ##=#100,##
 
   And then store each function as an attribute of the same name on object #100.
-  
+
   Continued in 'help @function4'.
 & @function4
   Normally, built in functions cannot be overriden by @functions. However, if a built-in function is deleted with @function/delete, you can then make a @function with the same name. "Deleted" built-ins can still be called through the FN() function, and can have restrictions applied with @function/restrict/builtin. @function/restore will delete the @function and turn the built in version back on.
@@ -1528,27 +1528,27 @@ See also: FLAGS, @set, @power, flag permissions
 See also: RESTRICT, FUNCTIONS, @startup, fn(), valid()
 & @grep
   @grep[/<switches>] <object>[/<attrs>]=<pattern>
-  
+
   @grep returns a list of all attributes on <object> which match <pattern>. If <attrs> is specified, only attributes which match the wildcard pattern <attrs> are checked; it defaults to "*". Use "**" for all attributes.
-  
+
   By default, attributes which contain the string <pattern> are returned. However, if the /wild switch is given, <pattern> is treated as a wildcard pattern, and attributes which match the pattern are returned. If the /regexp switch is given, <pattern> is treated as a regular expression, and attributes matching the regexp are returned. Please note that <pattern> will NOT be evaluated, so you can easily grep for code strings.
-  
+
   All matches are case-sensitive, unless the /nocase switch is given.
-  
+
   @grep only shows a list of matching attributes. However, you can specify the /print switch, in which case attribute values are also shown, with the matching substrings ansi-highlighted if appropriate.
-  
+
   If the /parent switch is given, attributes <object> inherits from its parent(s) will be checked as well.
 
   For backwards compatability, the /list switch provides the default behaviour of listing attributes without printing the values, and /ilist and /iprint are aliases for /list/nocase and /print/nocase.
-   
+
 See also: grep(), wildgrep(), regrep(), WILDCARDS
 & @halt
 & @allhalt
-  @halt[/noeval] <object>[=<action list>] 
+  @halt[/noeval] <object>[=<action list>]
   @halt/pid <pid>
   @halt/all
   @allhalt
- 
+
   The @halt command removes all queued actions for <object>. If given, <action list> is placed in the queue for the object instead. If no action list is specified, the object is set HALT.
 
   If <object> is a player, it clears the queue for the player and all of his objects. You can use "@halt me" to clear your own queue without setting yourself HALT.
@@ -1558,7 +1558,7 @@ See also: grep(), wildgrep(), regrep(), WILDCARDS
   @halt/pid will cancel a single queue entry with the given pid (the number in parenthesis before it in @ps). You must control the object that queued the command or have the halt power to do this.
 
   @halt/all is a synonym for @allhalt, and is a wizard-only command which halts all objects in the game in an effort to free up the queue.
-  
+
 See also: @wait, @ps, SEMAPHORES, @drain, @notify
 & @haven
   @haven <player>[=<message>]
@@ -1575,9 +1575,9 @@ See also: HAVEN, page, @lock, @away, @idle
   @hide[/<switch>] [<player>]
 
   This command allows players to hide their online status. Hidden connections don't show up on WHO, in lwho(), etc, when used by players without see_all.
-  
+
   The first form of this command affects the single connection specified by <descriptor> (as returned by ports(), or shown on the admin WHO). The second affects all connections for the given <player>, or the enactor if no <player> is given. You must be a Wizard, Royalty, or have the Hide @power to affect your own connections; only Wizards can affect other players' connections.
-  
+
   The /on and /yes switches hide connections, while /off and /no unhide connections. If no switch is given, the command acts as a toggle: for a single descriptor, the hide status is reversed. For a player, if all his connections are hidden, they will be unhidden. If any are unhidden, they will all be hidden.
 
 See also: hidden(), WHO, lwho(), lports(), ports()
@@ -1589,7 +1589,7 @@ See also: hidden(), WHO, lwho(), lports(), ports()
   @aidescribe <object>[=<action list>]
 
   @idescribe command sets the internal description for an object, which is shown to anyone who enters or looks while inside the object. It's only used for players and things; rooms and exits always use @describe.
-  
+
   The @oidescribe attribute is shown to others inside <object> when someone looks at the @idescribe, and the @aidescribe is triggered when someone lookst at the @idescribe.
 
   If there is no IDESCRIBE set for an object, those who enter or look inside it will see its @describe. In this case, others in the object will see nothing, and the @aidescribe will not be triggered. If you want to use @aidescribe without @idescribe, set @idescribe to a blank string, or to u(describe) to show the description.
@@ -1612,9 +1612,9 @@ See also: enter, @enter, ENTER_OK, @describe, look, @idescformat, VERBS
   Continued in 'help @hook2'.
 & @hook2
   In all cases, %# is the dbref of the object doing the command, and all hooks share the same set of q-registers. With /before and /after, the results of the evaluated attribute is thrown away like it was wrapped in a call of null(). Also, in cases where a command and function do the same thing (e.g., @pemit and pemit()), only the command gets the hooks.
-  
+
   A number of named registers are available in @hooks, accessible via r(<name>, args), containing the arguments passed to the command. The exact registers available depend on the command type and the arguments passed; see 'help @hook7' for a description of all possible registers.
-  
+
   Hooks can also be set in the alias.cnf file.
 
   Leaving out the object and attribute clears an existing hook. Wizards can see existing hooks with @command or @hook/list.
@@ -1623,30 +1623,30 @@ See also: enter, @enter, ENTER_OK, @describe, look, @idescformat, VERBS
 & @hook3
 
   @hook/override/inline and @hook/extend/inline allow you to write softcoded commands which act exactly like built-in commands - because they're run immediately, instead of being queued, output from the command appears in the right order relative to other commands in the action list. By default, commands hooked with /inline have access to the q-registers of the calling action list, and @breaks in the hooked command propagate to the calling action list, allowing you to write your own control structures.
-  
+
   For example, this adds a new command, @qbreak, which works like @break but stops command execution when %q0 contains a true value:
     > &qbreak #123=$@qbreak: @break %q0=@pemit/silent %#=Stopping.
     > @command/add @qbreak
     > @hook/override/inline @qbreak=#123, qbreak
-    
+
   This behaviour can be altered by adding the following switches to @hook/inline:
     /nobreak:   @breaks in the hooked command do not stop the calling action list from running
     /localize:  q-registers are saved before the hooked command is run, and restored after it completes
     /clearregs: All q-registers are reset before the hooked command is run. Most useful when used with /localize.
 
   @hook/inplace is an alias for @hook/inline/localize/clearregs/nobreak.
-  
+
   See 'help @hook6' for some examples of using @hook/override/inline.
 & @hook4
 
   @hook/extend can be used to add new features to a built-in command, via additional switches, without forcing you to also rewrite the existing functionality like @hook/override would. For example:
-  
+
   > &who`active #123=$who/active*: @nspemit %#=ufun(fun_who, lwho(%#), switch(%0, ?*, stringsecs(%0)))
   > &who`staff #123=$who/staff: @nspemit %#=ufun(fun_who, setunion(lwho(%#), lsearch(all, elock, type^player&(flag^wizard|flag^royalty)))
   > @hook/extend WHO=#123
-  
+
   This leaves the built-in WHO command working as normal, but adds two new switches for filtering the output in different ways.
-  
+
   @hook/igswitch is an alias for @hook/extend, for Rhost compatability.
 & @hook5
   An example of @hook:
@@ -1660,7 +1660,7 @@ See also: enter, @enter, ENTER_OK, @describe, look, @idescformat, VERBS
   Room Zero
   You are in Room Zero. It's very dark here.
   You're done looking.
-  
+
   > &cmd.say #3=$say *: @remit %L=if(hasflag(%#,OOC),<OOC>%b)%n says, "%0"
   > @hook/override say=#3, cmd.say
   > @set me=OOC
@@ -1690,7 +1690,7 @@ See also: enter, @enter, ENTER_OK, @describe, look, @idescformat, VERBS
 & @hook7
 
   The following named registers may be available (via r(<name>,args)) in your @hook, depending on the command hooked and the arguments given when run; use registers(,args) to get the available registers. /before, /after and /ignore hooks can also use the %u substitution to access the entire command string entered.
-  
+
   Register  Description
   --------  -------------------------------------------------------------
   Always available:
@@ -1698,30 +1698,30 @@ See also: enter, @enter, ENTER_OK, @describe, look, @idescformat, VERBS
   LS        If the command doesn't have multiple left-side args, LS is set to the entire left-side arg (before the = for EQSPLIT commands)
   LSAC      For commands with multiple left-side-args, the number of left-side args given
   LSAx      The xth left-side-arg, where x is between 1 and LSAC
-  
+
   Available for EQSPLIT commands:
   EQUALS    If the = was given, this is set to "="
   RS        For commands without multiple right-side args, this is the entire right-side arg (after the =)
   RSAC      For commands with multiple right-side-args, the number of right-side args given
   RSAx      The xth right-side-arg, where x is between 1 and RSAC
-  
+
   Available for SWITCHES commands (such as @lock):
   SWITCHES  The switch string given. (Note: Currently, switches given to normal commands are not available here, but can be accessed via the %u substitution.)
 
 & HUH_COMMAND
 
   This internal command is run whenever someone attempts to run a command which doesn't match any built-in or softcoded commands. The huh_command command cannot be run directly, but it can be @hook'd to perform custom actions when an invalid command is entered.
-  
+
   Examples:
     > &cmd.huh #0=$huh_command: @pemit/sil %#=Whu?
     > @hook/override huh_command=#0, cmd.huh
     > dsfsdf
     Whu?
-    
+
     > &cmd.huh #0=$huh_command *: @pemit/sil %#=Whu? What is '%0'?
     > sdfsdf ert
     Whu? What is 'sdfsdf ert'?
-    
+
     > &cmd.huh #0=$huh_command *: &typos %#=add(default(%#/typos,0),1) ; @pemit/sil %#=Huh? %b(Type "help" for help.) ; @break mod(get(%#/typos),10) ; @wall %n wins %p [ordinal(div(get(%#/typos),10))] typo trophy!
     > asfdsf  (10 times)
     Huh?  (Type "help" for help.)  (10 times)
@@ -1733,22 +1733,22 @@ See also: @hook, EVALUATION ORDER, warn_on_missing, unimplemented_command
 
   This message is sent in return to every page which successfully reaches you if it evaluates non-null. It is useful if you are idle for long periods of time and wish to inform people where you are, or if you are in a meeting and cannot quickly return pages.
 
-  Example: 
+  Example:
     > @idle me=switch(idle(me),>120,I'm idle. Use @mail)
 
   Players paging me will only see the "I'm idle" message if I've been idle for over 2 minutes (120 seconds).
-  
+
 See also: @away, @haven
 & @if
 & @ifelse
 & @skip
   @if <boolean>=<true>[, <false>]
   @skip <boolean>=<false>
-  
+
   If <boolean> is true, the action list <true> is run, otherwise the action list <false> is run. The action list is not queued, it is run immediately, in the same action list as @if.
-  
+
   For RhostMUSH compatability, @skip runs the action list <false> when <boolean> is false, and does nothing for true values.
-  
+
   @ifelse and @skip/ifelse are aliases for @if.
 
   See 'help @if2' for examples.
@@ -1773,7 +1773,7 @@ See also: @break, @switch, if(), BOOLEAN VALUES
     You say, "Sorry!"
 & @infilter
   @infilter <object>[=<pattern 1>[, <pattern 2>[, ..., <pattern N>]]]
-  
+
   @infilter is meant to be used on objects that have an @listen of "*" (ie, objects that listen to everything, which is commonly used for things like chairs so that someone inside the object can hear everything said/done outside it). @infilter filters out any messages that match one of the patterns and prevents those inside the object from hearing them. It does not stop the @ahear of the listening object from being triggered by things that match the @listen.
 
   Sounds are only forwarded if the speaker also passes <object>'s @lock/infilter, which receives the sound heard as %0.
@@ -1783,9 +1783,9 @@ See also: @break, @switch, if(), BOOLEAN VALUES
 See also: @filter, @listen, @inprefix, AUDIBLE, LISTENING
 & @inprefix
   @inprefix <object>[=<message>]
-  
+
   When an object has an @listen, any string it hears which is propagated to its contents will be prefixed with <message>. Useful for vehicles, etc, which have an @listen of "*".
-  
+
   Example:
     > @create Vehicle
     Created: Object #103.
@@ -1800,7 +1800,7 @@ See also: @filter, @listen, @inprefix, AUDIBLE, LISTENING
 See also: @prefix, @listen, @infilter
 & @kick
   @kick <number>
-  
+
   This wizard-only command forces the immediate execution of <number> items from the queue. Rarely useful. If your MUSH is lagging badly, chances are high that it stems from network problems. Check the queue before using this command.
 
 See also: @ps, QUEUE
@@ -1809,8 +1809,8 @@ See also: @ps, QUEUE
 
   Emits a message to the outermost container object. For example, if you are carrying a bird, and are inside a vehicle which is in room #10, and you force the bird to @lemit "Cheep", everyone in room #10 will hear "Cheep". This command is the same as "@emit/room".
 
-  With the /silent switch, no confirmation message is shown. With /noisy, it is. If neither is given, the silent_pemit option determines if it is shown. 
-  The /noeval switch prevents <message> from being evaluated. 
+  With the /silent switch, no confirmation message is shown. With /noisy, it is. If neither is given, the silent_pemit option determines if it is shown.
+  The /noeval switch prevents <message> from being evaluated.
   The /spoof switch causes nospoof notifications to show the enactor's dbref instead of the executor's dbref, and requires control over the enactor or the Can_spoof power.
 
 See also: @remit, @nslemit
@@ -1829,9 +1829,9 @@ See also: @remit, @nslemit
   flags       : Alias for @flag/list, shows all flags.
   powers      : Alias for @powers/list, shows all powers.
   allocations : Information about memory allocations. Admin-only.
-  
+
   By default, information is shown in upper-case. Add the /lowercase switch to show output in lowercase instead.
-  
+
   "commands" and "functions" show built-in and local commands/functions by default. The /builtin or /local switches can be given to limit this.
 
 See also: list(), @config, config(), functions(), @stats, @command, @function, @flag, @power, @attribute, @listmotd, @motd, locktypes
@@ -1854,27 +1854,27 @@ See also: EXITS, @open, @dig, DROP-TO, HOME
 & Variable Exits
   @destination <exit>[=<destination>]
   @exitto <exit>[=<destination>]
-  
+
   The DESTINATION attribute is used by variable exits. To make a variable exit, you create it in the usual way (with @open), then @link it to "variable" instead of a dbref. When someone attempts to pass through the exit, the DESTINATION attribute will be evaluated, and should return a dbref; the dbref will be used as the location for the person to go to. The exit name or alias the moving player used is passed to the attribute as %0.
-  
+
   The exit must be able to @link itself to the dbref returned by the attribute. This means the exit must control the destination, the destination must be set LINK_OK, or the exit must have the Link_Anywhere @power.
-  
+
   If no DESTINATION attribute is set on a variable exit, the MUSH will also check for an EXITTO attribute, for cross-platform compatability. It works exactly the same as the DESTINATION attribute.
-  
+
   Note that, unlike most attributes, @destination cannot be abbreviated and must be typed in full.
-  
+
   Example:
     > @open Random Exit;re
     > @link re=variable
     > @power re=link_anywhere
     > @destination re=pickrand(#5 #123 #999 [home(%#)] %L)
-  
+
 See also: EXITS, @link, @open, LINK_OK, Link_Anywhere Power
 & @listen
   @listen <object>[=<pattern>]
 
   Sets the object's listen pattern to <pattern>, which can have wildcards. Whenever something the object hears matches the pattern, the object's ahear/amhear/aahear attribute will be triggered. In addition, anything inside the object will hear it as well, if the speaker passes @lock/infilter.
-  
+
   Rather than using @listen, it's recommended you use ^-listening patterns, which can be set in any attribute similar to $-commands. This allows for descriptive attribute names, and also allows multiple patterns per object. See 'help ^' for more information.
 
   For example:
@@ -1906,8 +1906,8 @@ See also: LISTENING, @ahear, @amhear, @aahear, WILDCARDS
 & LOCKING
 & LOCKS
 & @lock
-  @lock[/<switch>] <object>=<key> 
-  
+  @lock[/<switch>] <object>=<key>
+
   This command "locks" the object, specifying a key which determines who or what can do certain things with the object. There are many different types of locks, all of which are described in 'help locktypes' and which are designated by the switch. The "basic" lock determines, for players and things, who can pick them up. For exits, it determines who can go through the exit. All other locks can be set the same way as the basic lock.
 
   Whenever you "pass" the basic lock, you succeed in doing something with the object. This triggers the @success/@osuccess/@asuccess messages and actions. If you fail to pass the basic lock, you trigger the @failure/@ofailure/@afailure messages and actions. Other locktypes may also have such success/failure messages: see 'help failure' for info.
@@ -1922,7 +1922,7 @@ See also: @lock-simple, locktypes, lockkeys, @clock, failure, success, elock(), 
 
   This commands sets or clears flags on locks.
   Valid flags include:
-  
+
   visual     (v)     This lock can be seen even if the object it's on isn't visual.
   no_inherit (i)     This lock isn't inherited off of parents. All locks are set no_inherit by default.
   no_clone   (c)     This lock isn't copied by @clone.
@@ -1933,7 +1933,7 @@ See also: @lock, lockflags(), llockflags(), lset()
 & @log
   @log[/<switch>] <message>
   @log/recall/<switch> [<number>]
- 
+
   This wizard-only command puts <message> in a log file, tagged with the time and object executing the command. The available switches are /check, /cmd, /conn, /err, /trace, and /wiz, specifying which file to log to. /cmd is default.
 
   Adding the /recall switch will display the last <number> lines written to that log file, or the entire log buffer (Which is the last 1 kilobyte or so of data written to the log) if omitted.
@@ -1952,7 +1952,7 @@ See also: @logwipe
   /rotate : copies the log to a backup file and then erases it.
   /trim   : deletes all but the most recent lines in the file.
   /wipe   : erases the file (Default)
- 
+
   God must give the log wipe password from the MUSH's configuration file to use this command.
 
 See also: @log
@@ -1962,11 +1962,11 @@ See also: @log
   @message is designed for the use of *format messages, such as @pageformat or @chatformat. It is intended for use with @hooking page, @chat, or say/pose/emit, or for coding language systems.
 
   For each of the given <recipients>, <obj>/<attr> is evaluated (with up to 30 arguments, as if it was ufun()'d), and the object is shown the result via @pemit. If the attribute does not exist, or you do not have permission to evaluate it, they are shown <defmsg> instead.
-  
+
   If <obj> is not given, or is given as "#-2", the attribute will be checked on the recipient.
 
   If one of the arguments matches "##", it will be replaced with the dbref of the recipient.
-  
+
   Switches:
     /noeval   -- none of @message's arguments will be evaluated
     /spoof    -- the message will appear to be from the enactor, not the executor. Requires the Can_Spoof @power
@@ -1985,7 +1985,7 @@ See also: message(), @chatformat, @pageformat, @oemit, @remit, speak()
     > &sayformat *Walker=From %n: %0
     > &cmd.fsay me=$fsay *: @message/spoof *Mike *Walker *Javelin=%n says\, "%0", SAYFORMAT, %0
     > fsay This is a test
-    
+
   Mike sees:
     Player sez, 'This is a test'
   Walker sees:
@@ -2007,7 +2007,7 @@ See also: message(), @chatformat, @pageformat, @oemit, @remit, speak()
     > &translate Globals=switch(default(%0/skill`%1, 2), 2, %2, speak(%#, |%2,, %!/translate`some))
     > &translate`some Globals="[iter(%0,if(rand(2),%i0,...))]"
     > +spanish The rain in Spain falls mainly on the plain
-    
+
   You see:
     You say (Spanish), "The rain in Spain falls mainly on the plain"
   Bob sees (something like):
@@ -2017,15 +2017,15 @@ See also: message(), @chatformat, @pageformat, @oemit, @remit, speak()
 
 & @moniker
   @moniker <object>[=<moniker>]
-  
+
   This command sets or clears the "moniker" for <object>. A moniker is an ansi template, to show the object's name in color. Exactly where this color is displayed depends on the "monikers" @config option; see 'help monikers' for more information.
-  
+
   <moniker> can contain any text - it will be ignored, and only the ansi colors will be taken into account. If <object>'s name is longer than <moniker>, the last color will be used for the remaining letters.
-  
+
   Examples:
    Display your name in highligted red
    > @moniker me=ansi(hr,-)
-   
+
    Show the first letter in orange, and the rest with no color
    > @moniker me=ansi(+orange,-)[ansi(n,-)]
 
@@ -2039,9 +2039,9 @@ See also: MONIKERS, moniker(), ansi(), @nameformat, @nameaccent, MONIKER
   @motd/list
 
   This command is used for manipulating the various Messages of the Day, or MotD. The first form of this command sets the <type> MotD to <message>, the second form clears the <type> MotD, and the third form lists the current value of each MotD. If no switch is given, <type> defaults to /connect.
-  
+
   These messages are intended for temporary announcements; the given <message> is shown in addition to the standard MotDs defined in the mush.cnf options. MotDs set via this command are cleared when the MUSH restarts.
-  
+
   Valid <type>..   shown with..   and is seen by...
   /connect         motd_file      all players on connect
   /wizard          wizmotd_file   connecting Wizards and Royalty
@@ -2058,11 +2058,11 @@ See also: MONIKERS, moniker(), ansi(), @nameformat, @nameaccent, MONIKER
   Changes the name of <object> to <new name>.
 
   Players can change their name to anything valid which is not currently in use by another player, as a name or alias. (They can change their name to something from their own @alias.)
-  
+
   You can change the alias for a player or exit while renaming it, by giving the alias(es) after the new name, each separated by a semicolon. If the name is followed by a semicolon with no aliases, the existing alias will be cleared instead.
 
   When <object>'s name is changed, its ONAME and ANAME verb attributes will be triggered. See 'help @oname' for details.
-  
+
   Examples:
     > @name here=My Room
     Name set.
@@ -2072,16 +2072,16 @@ See also: MONIKERS, moniker(), ansi(), @nameformat, @nameaccent, MONIKER
     > @name me=Obi Wan;
     Alias removed.
     Name set.
-  
+
 See also: @alias, @oname, name(), fullname()
 Config options: player_name_spaces, player_name_len, only_ascii_in_names
 & @ONAME
 & @ANAME
   @oname <object>[=<message>]
   @aname <object>[=<action list>]
-  
+
   Whenever <object>'s name is changed (via @name), others in the same location will see the contents of <object>'s ONAME attribute, prepended with <object>'s new name. At the same time, <object>'s ANAME attribute will be triggered. Both attributes receive the old name as %0, and the new name as %1.
-  
+
     Example:
       > @oname me=has regenerated from %0!
       > @aname me=think >> Renamed from %0 to %1 at [time()] by %n(%#).
@@ -2092,17 +2092,17 @@ See also: @name, name(), VERBS
   @newpassword/generate <player>
 
   This wizard-only command changes <player>'s password. If <player> is connected, she will be informed that the password was changed and who by, but not what it was changed to.
-  
+
   The <player> argument is evaluated, but the <password> argument is not when the command is entered directly from a client.
-  
+
   If the /generate switch is given, a new, random password is generated automatically, and shown to the enactor (but not to <player>).
   The <password> must not contain whitespace, unprintable characters, or '='.
-  
+
 See also: @password, checkpass()
 & @notify
   @notify[/any][/all] <object>[/<attribute>][=<number>]
   @notify/setq <object>[/<attribute>]=<qreg1>,<qval1>[,...]
-  
+
   This command notifies a semaphore, allowing commands queued for that semaphore to be executed.
 
   If the /any switch is given, then all semaphores associated with <object> are @notified. Otherwise, only the specified semaphore <attribute> (or SEMAPHORE if no attribute is specified) is @notified.
@@ -2110,7 +2110,7 @@ See also: @password, checkpass()
   If the /all switch is given, then all queue entries associated with the selected semaphore(s) are executed. Otherwise, only the first <number> of queue entries are run. If no <number> is given, then only one queue entry is run.
 
   If the /all switch was not used, and there were not enough queue entries waiting to satisfy the requested <number>, then the semaphore becomes negative, and subsequent @waits will not block until it reaches 0 again.
-  
+
   You may not specify both the /any switch and a specific attribute. Similarly, you may not specify both the /all switch and a number.
 
   Continued in 'help @notify2'.
@@ -2145,11 +2145,11 @@ See also: SEMAPHORES, @drain, @wait, @halt
 See also: @emit, @lemit, @pemit, @prompt, @remit, @oemit, @zemit, nsemit(), nslemit(), nspemit(), nsprompt(), nsremit(), nsoemit(), nszemit(), PROMPT_NEWLINES
 & @oemit
   @oemit[/<switch>] [<room>/]<object> [... <object>]=<message>
- 
+
   This command shows <message> to everyone in the location of <object> EXCEPT <object>. A list of objects can be given, in which case the message is shown in the locations of each, to everyone but those objects. If <object> contains a space, it should be enclosed in double-quotes.
-  
+
   If <room> is specified (usually as a dbref), this command shows <message> to everyone in <room> except for the given <object>s. In this case, each <object> is matched relative to <room>. If no matching <object>s are found in <room>, this is the equivilent of @remit <room>=<message>.
-  
+
   The /noeval switch prevents the MUSH from evaluating <message>.
   The /spoof switch causes nospoof notifications to show the enactor's dbref instead of the executor's dbref, and requires control over the enactor or the Can_spoof power.
 
@@ -2159,19 +2159,19 @@ See also: @emit, @pemit, @nsoemit, oemit(), nsoemit(), NOSPOOF, SPOOFING
   Examples:
     Show a message in the locations of players Bob and Fred, to everyone except those two players:
     > @oemit *Bob *Fred=Bob throws a paper aeroplane at Fred.
-    
+
     Show a message in #50 to everyone except the object 'Spy'.
     > @oemit #50/Spy=Sssh!
-    
+
     Show a message to everyone in your current location, except the 2nd object called 'foo'.
     > @oemit %L/"2nd foo"=bar
 & @open
   @open <exit name>[=<destination>,<return exit name>,<source room>,<dbref>,<return dbref>]
 
   This command opens an exit, named <exit name>, in your current location, or in <source room> if one is given. Exits can only be opened from rooms. If a <destination> is given, the exit will be linked (as per @link) to that object. If you don't have permission to link to <destination>, the exit will be created but unlinked.
-  
+
   If <return exit name> is given, the MUSH will attempt to open an exit back from <destination> and link it to <exit name>'s source.
-  
+
   Both <exit name> and <return exit name> can include any number of aliases for the exits, separated by semicolons. See 'help @name' for details.
 
   Wizards and objects with the pick_dbref power can specify garbage dbrefs to use for the exit and return exit.
@@ -2180,20 +2180,20 @@ See also: @emit, @pemit, @nsoemit, oemit(), nsoemit(), NOSPOOF, SPOOFING
 
   Example:
     > @open Up <U>;up;u;climb=#255, Down <D>;down;d;fall
-  
+
 See also: EXITS, @link, @dig, open()
 & @parent
   @parent <object>[=<parent>]
- 
+
   This command sets the parent of <object> to <parent>. If no <parent> is given, or <parent> is "none", <object>'s parent is cleared. You must control <object>, and must either control <parent> or it must be set LINK_OK and you must pass its @lock/parent.
-  
+
 See also: PARENTS, parent(), lparent(), ANCESTORS
 & @password
   @password <old password>=<new password>
 
   This changes your password. Please note that passwords ARE case-sensitive. The arguments are not evaluated.
   The <new password> must not contain whitespace, unprintable characters, or '='.
-  
+
 See also: @newpassword, checkpass()
 & @pageformat
 & @outpageformat
@@ -2231,7 +2231,7 @@ See also: page, speak(), @chatformat, @speechmod, @message
   @areceive <recipient>[=<action list>]
 
   These attributes contain the message shown <recipient> when he receives an object (via 'get' or 'give'), the message shown to others in <recipient>'s location when he receives an object, and the actions to be taken by <recipient> when he receives an object, respectively.
-  
+
   In all cases, %0 is the dbref of the object received. If the object was 'give'n, %1 will be the dbref of the giver.
 
 See also: give, get, @give, @success, ACTION LISTS, VERBS
@@ -2241,9 +2241,9 @@ See also: give, get, @give, @success, ACTION LISTS, VERBS
   @give <giver>[=<message>]
   @ogive <giver>[=<message>]
   @agive <giver>[=<action list>]
-  
+
   These attributes contain the message shown to <giver> when he gives an object, the message shown to others in <giver>'s location when he gives an object, and the actions to be taken by <giver> when he gives an object, respectively.
-  
+
   In all cases, %0 is the dbref of the object being given, and %1 is the dbref of the recipient.
 
 See also: give, @receive, ACTION LISTS, VERBS
@@ -2251,13 +2251,13 @@ See also: give, @receive, ACTION LISTS, VERBS
   @pcreate <name>=<password>[, <dbref>]
 
   This wizard-only command creates a player with the given name and password. If specified, <dbref> is the dbref of a garbage object to be used for the new player.
-  
+
 See also: pcreate()
 & @prompt
   @prompt[/<switch>] <dbref list>[=<message>]
 
   A variation of @pemit/list that adds a telnet GOAHEAD control code to the end of messages sent to players. Players with clients that handle GOAHEAD may get the message as a prompt in their client's input area.
-  
+
   If <message> is omitted, an empty prompt is sent.
 
   @prompt supports the following @pemit switches: /silent, /noisy, /spoof, /noeval
@@ -2275,11 +2275,11 @@ See also: @prompt, prompt(), terminfo(), @sockset
   @pemit[/<switches>] <object>=<message>
   @pemit/list[/<switches>] <object list>=<message>
   @pemit/port[/list][/silent] <descriptor(s)>=<message>
-  
+
   The basic form of this command sends <message> to <object> directly. It is very similar in its effects to @emit except only one object will see the message.
- 
+
   @pemit/list sends the message to multiple objects. You will not get a confirmation message when using this switch.
-  
+
   @pemit/port can only be used by Wizards/Royalty, and sends <message> to one or more connections. It can be used to send messages to connections which are still at the login screen, or to send a message to just one of a player's connections when he's logged in multiple times.
 
   See 'help @pemit2' for more.
@@ -2288,8 +2288,8 @@ See also: @prompt, prompt(), terminfo(), @sockset
     /contents  -- equivalent to @remit.
     /silent    -- does not tell the @pemit'ing object a confirmation message.
     /noisy     -- tells the @pemit'ing object a confirmation message.
-    /noeval    -- <message> will not be evaluated for substitutions 
-    /spoof     -- the enactor's dbref will be used for nospoof notifications instead of the executor's dbref. Requires control over enactor or Can_spoof power. 
+    /noeval    -- <message> will not be evaluated for substitutions
+    /spoof     -- the enactor's dbref will be used for nospoof notifications instead of the executor's dbref. Requires control over enactor or Can_spoof power.
 
   You cannot @pemit to objects set HAVEN, or objects whose @lock/page you do not pass, unless you are set WIZARD or have the pemit_all @power.
 
@@ -2304,7 +2304,7 @@ See also: @emit, @nspemit, @oemit, @remit, NOSPOOF, SPOOFING, page
 See also: @doing, WHO, DOING
 & @poor
   @poor <value>
-  
+
   This command sets the pennies of every player on the MUSH to <value>. It can only be used by God.
 
 See also: MONEY, give
@@ -2312,7 +2312,7 @@ See also: MONEY, give
   @power/list [<power name pattern>]
   @power <power>
   @power <object>=[!]<power>
-  
+
   @power/list lists the defined powers (see 'help powers'). A list of standard powers with explanations is given in 'help powers list'. When given a power name as an argument, @power displays information
   about a power.
 
@@ -2330,53 +2330,53 @@ See also: powers(), @flag
   @power/type <power>=<type(s)>
   @power/enable <power>
   @power/disable <power>
-  
+
   These commands manipulate power definitions. Only God may use them.
     /disable disables a power, making it invisible and unusable
     /enable re-enables a disabled power
     /alias adds a new alias for an existing power
     /letter changes or removes a single-letter alias for an existing power.
-    /restrict changes power permissions (see help @power3) 
-    /type changes power type(s) (see help @power3) 
-    /delete deletes a power completely, removing it from all objects in the database and the removing it permanently from the power table. It requires the exact power name or alias to be used. Be very very careful with this. 
-  
+    /restrict changes power permissions (see help @power3)
+    /type changes power type(s) (see help @power3)
+    /delete deletes a power completely, removing it from all objects in the database and the removing it permanently from the power table. It requires the exact power name or alias to be used. Be very very careful with this.
+
   See help @power3 for information on @power/add
 & @power3
   @power/add is used to add a new power with the given name. Arguments other than the power name are optional:
-  
-  <letter> gives the power's one-letter abbreviation, which must not conflict with the one-letter abbreviation of another power that could be applied to the same object type(s). It defaults to none, which means it won't appear in a list of power characters but can still be tested for with haspower(), andlpowers(), and orlpowers(). 
-  <type> specifies the space-separated list of types to which the power applies, and may be 'any' or one or more of 'room', 'thing', 'player', or 'exit'. It defaults to 'any'. 
+
+  <letter> gives the power's one-letter abbreviation, which must not conflict with the one-letter abbreviation of another power that could be applied to the same object type(s). It defaults to none, which means it won't appear in a list of power characters but can still be tested for with haspower(), andlpowers(), and orlpowers().
+  <type> specifies the space-separated list of types to which the power applies, and may be 'any' or one or more of 'room', 'thing', 'player', or 'exit'. It defaults to 'any'.
   <setperms> specifies the space-separated list of permissions for who can set and/or see the power. See 'help flag permissions' for details. It defaults to 'any'
   <unsetperms> specifies the space-separated list of permissions for who can clear the power on an object they control. It defaults to whatever <setperms> is given, or 'any'.
 
   Powers added with @power/add are saved with the database when it is dumped, and do not need to be re-added at startup. They are treated exactly as any other power in the server.
 & @prefix
   @prefix <object>[=<message>]
- 
+
   This attribute is meant to be used in conjunction with the AUDIBLE flag. The @prefix of the object is prepended to messages propagated via AUDIBLE. Pronoun substitution is done on @prefix messages.
-  
+
   For example, if you have an audible exit "Outside" leading from a room Garden to a room Street, with @prefix "From the garden nearby," if Joe does a ":waves to everyone." from the Garden, the people at Street will see the message, "From the garden nearby, Joe waves to everyone."
 
 See also: @inprefix, AUDIBLE, @listen
 & @ps
   @ps[/<switch>] [<player>]
   @ps[/debug] <pid>
-  
+
   @ps lists all commands currently on your 'to be executed' queue, thus allowing you to identify infinite (or unnecessary) loops with-out putting in says or poses. It gives a count of the total commands in each of the queues (Command, Wait, and Semaphore), displayed in the format:
       <Number of your queued commands> / <Total number of queued commands>.
 
   Some of the queues also include a [Ndel] after the total. That number is the number of entries made by objects that have been halted but haven't been removed from the queue yet.
-      
+
   It also shows a running load average of the number of queue entries executed per second for the last 1, 5 and 15 minutes.
 
   @ps with no arguments will show you your own queue. Wizards may specify the /all switch, and see the full queue. They may also specify a player. @ps/summary just displays the queue totals for the whole queue. @ps/quick displays the queue totals for just your queue.
-  
+
   Continued in 'help @ps2'.
 & @ps2
   With a <pid> argument, @ps shows information on a single queue entry. The /debug switch will also display the queue entry's environment: Arguments, q registers, executor, enactor and caller dbrefs.
 
   Each line includes the process id of the queue entry, the object and attribute being used as a semaphore (if any), the number of seconds left before it executes (for waits and semaphores), the object that is going to execute the entry, and the command. To halt a specific queue entry, use @halt/pid.
-  
+
 See also: @wait, @halt, @notify, @drain, SEMAPHORES
 & @purge
   @purge is a wizard only command that calls the internal purge routine to advance the clock of each object scheduled to be destroyed, and destroy those things whose time is up. The internal purge routine is normally run automatically approximately every 10 minutes.
@@ -2388,7 +2388,7 @@ See also: @dbck
   @quota [<player>]
 
   These commands are only meaningful if the Quota system is enabled (check the use_quota @config option).
-  
+
   @quota shows the current quota for <player>, or for the executor if no <player> is given. You must control <player>, or have either the See_All or Quotas @power.
 
   Continued in 'help @quota2'.
@@ -2399,18 +2399,18 @@ See also: @dbck
   @allquota[/quiet] [<limit>]
 
   @squota is a Wizard-only command which adjusts the quota of <player>. If <amount> is prefixed by + or -, their current quota will be incremented or decremented by <amount>, respectively. Otherwise, their total quota is set to <amount>.
-  
+
   @allquota can only be used by God. With no <limit> argument, it reports the quotas of all players. If a <limit> is given, the quotas of all players is reset to <limit>. The /quiet switch stops @allquota reporting the current quotas before changing them.
-  
+
   Players always have enough quota for the objects they currently own; if you attempt to set their quota to a lower number (with @squota or @allquota), it will be set to the number of objects they own instead.
-  
+
   @quota/set and @quota/all are equivilent to @squota and @allquota, respectively.
 
 See also: QUOTAS, Quotas Power, No_Quota Power
 & @readcache
   @readcache
-  
-  This wizard-only command reloads the cached text files (listed under '@config messages') and rebuilds the indexes for help, news and similar commands. 
+
+  This wizard-only command reloads the cached text files (listed under '@config messages') and rebuilds the indexes for help, news and similar commands.
 
   On some systems (where '@config compile' shows 'Changed help files will be automatically reindexed.'), updates to these files are noticed and loaded automatically. Otherwise, @readcache must be used any time changes are made to one of these files while the game is running.
 
@@ -2425,7 +2425,7 @@ See also: @shutdown
   Sends the message to all contents of <object>, which can be a room, thing, or player. The message is also sent to the <object> itself. (The TinyMUSH equivalent is @pemit/contents).
 
   The /silent switch stops the remitter from getting feedback if they're in a different location than the target.
-  The /noisy switch always gives feedback to the remitter if they are not in the target location. 
+  The /noisy switch always gives feedback to the remitter if they are not in the target location.
   (Without /silent or /noisy, the silent_pemit config option is used to determine noisiness.)
   The /list switch will send the message to the contents of multiple objects at the same time. The <object> argument is treated as a space-separated list of targets.
   The /spoof switch causes nospoof notifications to show the enactor's dbref instead of the executor's dbref, and requires control over the enactor or the Can_spoof power.
@@ -2465,41 +2465,41 @@ See also: ACTION LISTS, BOOLEAN VALUES, @break, @include
 & @restart
   @restart <object>
   @restart/all
-  
+
   This command halts <object> (as described in @halt), and then triggers the STARTUP attribute on the object, if set. If <object> is a player, it affects the player and all of their objects. Players can use @restart me to restart their own objects. The /all switch halts all objects (see @allhalt) and restarts them, and can only be used by a wizard.
 
 See also: @halt, @startup, @shutdown
 & @scan
   @scan[/<switches>] <command>
-  
+
   @scan gives you a list of all objects containing $-commands (user-defined commands) which could match <command>. If given no switches, it checks you, your possessions, your location, objects in your location, the zone/zone master room of your location, your zone, and objects in the master room. It does NOT stop when it gets a match, but rather, finds all possible matches. It also tells how many commands on each object were matched, and what attributes they are in. It does NOT scan objects that you do not control and are not set VISUAL.
-  
+
   This command any combination of these four switches:
      /room     --   just matches on your location and objects in it.
      /self     --   just matches on you and anything you're carrying.
      /zone     --   just matches on zones of your location and yourself.
      /globals  --   just matches on objects in the master room.
-     
+
   If no switch is given, all locations are checked. <command> must be entered exactly as you would type it (so, to match the $-command $foo *: you must type '@scan foo <something>', not just '@scan foo').
-  
+
 See also: $-commands, EVALUATION ORDER
 & @search
   @search [<player>] [<classN>=<restrictionN>[,...]][,<begin>,<end>]
-  
+
   This command searches the database and lists objects which meet user specified search criteria. You can limit the scope of the search by specifying <begin> and <end> as the first and last dbrefs to search.
-  
+
   If a <player> argument is supplied, only objects owned by that player will be listed, or all objects if "all" is used. Mortals attempting to match other players (aside from ZMPs whose @lock/zone they pass) or "all" will only get objects which they can examine.
-  
+
   <class> and <restriction> arguments can be given to filter the match results. Possible <class>es include TYPE, NAME, ZONE, PARENT, EXITS, THINGS (or OBJECTS), ROOMS, PLAYERS, FLAGS, LFLAGS, POWERS, ELOCK, COMMAND, LISTEN, EVAL, EPLAYER, EROOM, EEXIT, and ETHING (or EOBJECT).
 
   If <class>=TYPE, possible <restriction>s include THING (or OBJECT), ROOM, EXIT, PLAYER, GARBAGE. This shows all objects of the specified type.
-  
+
   If <class>=NAME, only objects whose name begin with the string <restriction> will be listed. If <class>=EXITS, OBJECTS, ROOMS or PLAYERS, only objects of that type whose name begins with <restriction> are listed.
-  
+
   If <class>=ZONE, only objects in the zone <restriction> will be listed.
   If <class>=PARENT, only children of parent <restriction> will be listed.
   For ZONE and PARENT, <restriction> must be specified as a dbref number.
-  
+
   Continued in 'help @search2'.
 & @search2
   If <class>=FLAGS or LFLAGS, only objects with the list of flags specified by <restriction> will be listed. For FLAGS, flags to match should be given as a string of single flag letters, with appropriate case. For LFLAGS, flags to match should be given as a space-separated list of flag names.
@@ -2507,9 +2507,9 @@ See also: $-commands, EVALUATION ORDER
   If <class>=POWERS, only objects with the given powers are listed. <restriction> should be a space-separated list of power names.
 
   If <class>=ELOCK, only objects that pass the given lock string (as in help @lock) are listed. For purposes of indirect locks (@#123), 'search' is the name of the lock.
-  
+
   If <class>=EVAL, only objects for which <restriction> evaluates to a true boolean value will be listed. The token '##' in <restriction>, which is a function, is replaced by each dbref sequentially. Classes EPLAYER, EROOM, EEXIT, and ETHING work like EVAL but are restricted to a single type.
-  
+
   Continued in 'help @search3' for more.
 & @search3
   If <class>=MINDB, only objects with dbrefs of <restriction> or higher will be listed. If <class>=MAXDB, only objects with dbrefs of <restriction> or lower will be listed.
@@ -2524,13 +2524,13 @@ See also: $-commands, EVALUATION ORDER
 
   Continued in 'help @search4'.
 & @search4
-  
+
   For the class TYPE=PLAYER, and for PLAYER=<player-name>, anyone may obtain information on any player. In all other cases, wizards may obtain information about other players, and players who pass a ZMP's zone-lock may obtain information about the ZMP.
 
   If multiple <class> and <restrictions> are given, objects must meet all criteria in order to match successfully. The exception to this is that if multiple 'type' searches (PLAYER, EROOM, etc) are used, only the last type given is used in the search.
 
   @search is only mildly computationally expensive for most of the search classes. Computationally expensive searches are the evaluating searches (EVAL, EPLAYER, ETHING, EROOM, EEXIT), the attribute pattern searches (COMMAND, LISTEN), and ELOCK searches which perform evaluation searches (attr/value) or indirect locks (@obj/lock). These searches all cost a number of pennies (the exact amount is configurable; see @config find_cost).
-  
+
   See 'help @search5' for some examples.
 See also: lsearch(), @find
 & @search5
@@ -2548,7 +2548,7 @@ See also: lsearch(), @find
   @<pre-defined attribute> <object>=<value>
   @set <object>=<attribute>:<value>
   @set <object>/<attribute>=[!]<attrflag>
-  
+
   The first form sets (or unsets) flag(s) on <object>. See 'help flags'.
     Ex: @set me=VISUAL
   Flags may be specified by full name (recommended) or by flag character.
@@ -2561,25 +2561,25 @@ See also: lsearch(), @find
     Ex: @set Test Object=random:This is a random attribute.
         &random Test Object=This is a random attribute.
   An important difference between these two forms is that @set will always evaluate the <value> before setting it on <object>, while the &<attribute> form will not evaluate when entered directly by a player in his client (and is usually what you want).
-  
+
   The fourth form sets (or unsets) an attribute flag on the specified attribute. See 'help attribute flags'.
-  
+
 See also: ATTRIB_SET, attrib_set(), set()
 & ATTRIB_SET
 & @_
   &<attr> <object>[=<value>]
   @_<attr> <object>[=<value>]
   ATTRIB_SET/<attr> <object>=<value>
-  
+
   The &<attr> and @_<attr> commands can be used to set or clear an attribute from an object. When entered directly from a client, they do not evaluate the <value>.
-  
+
   ATTRIB_SET is the internal command which powers &attr and @_attr setting; it cannot be used directly, but can be restricted or @hook'd to change the behaviour of &attr/@_attr-setting.
 
 See also: @set, attrib_set()
 & @sex
   @sex <player>[=<gender>]
 
-  You can use this command to set yourself or any of your objects to be male, female, neuter, or plural. The SEX attribute is used for pronoun substitution by the MUSH, and anything not recognizable will be treated as neuter. 
+  You can use this command to set yourself or any of your objects to be male, female, neuter, or plural. The SEX attribute is used for pronoun substitution by the MUSH, and anything not recognizable will be treated as neuter.
 
   Examples:
     > @sex me=Male
@@ -2609,7 +2609,7 @@ See also: GENDER, subj(), poss(), aposs(), obj()
   @sitelock/remove[/player] <string>
 
   The @sitelock command adds rules to the access.cnf file, controlling a host's level of access to the MUSH, or adds banned player names to the names.cnf file. Only Wizards may use @sitelock.
-  
+
   @sitelock without arguments lists all sites in access.cnf. Rules are processed in the order listed, and the first matching rule is applied. @sitelock/check tells you which rule will match for a given <host>.
 
   @sitelock/name adds a name to the list of banned player names. Use !<name> to remove a name from the list.
@@ -2617,11 +2617,11 @@ See also: GENDER, subj(), poss(), aposs(), obj()
   @sitelock <host-pattern>=<options>[, <name>] controls the access options for hosts which match <host-pattern>, which may include wildcard characters "*" and "?". See help @sitelock2 for the list of options, and help @sitelock3 for an explanation about the name argument.
 
   For backward compatibility, @sitelock/ban is shorthand for setting options "!connect !create !guest", and @sitelock/register is shorthand for options "!create register".
-  
+
   If the /player switch is given, <host-pattern> is treated as a player name, and sitelock rules are added for that player's LASTIP and LASTSITE, if set.
 
   Continued in 'help @sitelock2'.
-See also: WILDCARDS, REGEXPS, ipaddr(), hostname()  
+See also: WILDCARDS, REGEXPS, ipaddr(), hostname()
 & @sitelock2
 
   Sitelock allow/deny options:
@@ -2664,7 +2664,7 @@ Continued in 'help @sitelock3'
   Two different daemons are used:
 
   info: Resolves IP addresses into host names whenever a new connection is established.
-  ssl : Handles encrypted SSL connections across @shutdown/reboots. 
+  ssl : Handles encrypted SSL connections across @shutdown/reboots.
 
 & @SOCKSET
 & SOCKSET
@@ -2672,9 +2672,9 @@ Continued in 'help @sitelock3'
   @sockset [<descriptor>][=<option>, <value>[, ..., <optionN>, <valueN>]]
 
   SOCKSET is a socket command which sets or queries socket-specific options. These options are usually set automatically, or negotiated by the MUSH and your client, but this command lets you override those settings.
-  
+
   With no args, SOCKSET shows the current value of the socket options. With an <option>=<value> pair, it attempts to set the given option.
-  
+
   @sockset is a similar in-game command, but can specify which descriptor to change options for, and can set multiple options at once. Only Wizards can change the options for other players' descriptors. <descriptor> defaults to your least-idle descriptor, when used by a player; for non-players, it has no default.
 
   Options:
@@ -2688,9 +2688,9 @@ Continued in 'help @sitelock3'
     terminaltype:    Your terminal type, used by terminfo()
     prompt_newlines: Set whether a newline is shown after prompts from @prompt, same as PROMPT_NEWLINES
     stripaccents:    Strip accents for this connection. Like the NOACCENTS flag, but connection-specific. Set by default on connections which negotiate charset as [US-]ASCII
-
+    noquota          Sets the command quota limit to the maximum every refresh for this connection, can only be set by a logged-in Wizard.
   Note that changing 'telnet' or 'pueblo' may stop your client from parsing or displaying output correctly; only use if you know what you're doing!
-  
+
 See also: SOCKET COMMANDS, terminfo(), Pueblo, colorstyle, @prompt
 & COLORSTYLE
   SOCKSET colorstyle=<value>
@@ -2711,18 +2711,18 @@ See also: SOCKET COMMANDS, terminfo(), Pueblo, colorstyle, @prompt
 See also: ANSI, COLOR, XTERM256, @sockset
 & @SPEECHMOD
   @speechmod <object>[=<modifier>]
-  
+
   When set, this attribute modifies everything <object> says, poses, semiposes and @emits. The original text spoken/posed/emitted is passed as %0, with %1 passed as " (for say), : (for pose), ; (for semipose) or | (for @emit).
-  
+
   If the attribute evaluates to an empty string, the original text will be used. Otherwise, the result of the attribute is used.
-  
+
   Example:
     > @speechmod me=ucstr(%0)!
     > say hello
     You say, "HELLO!"
     > pose waves
     Bob WAVES!
-    
+
     > @speechmod me=switch(%1,",ucstr(%0),:,lcstr(%0))
     > say Test
     You say, "TEST"
@@ -2730,7 +2730,7 @@ See also: ANSI, COLOR, XTERM256, @sockset
     Bob test
     > @emit Test
     Test
-    
+
 See also: say, pose, @emit, @chatformat, @pageformat
 & @mapsql
   @mapsql[/notify][/colnames][/spoof] <obj>/<attr>=<query>
@@ -2742,13 +2742,13 @@ See also: say, pose, @emit, @chatformat, @pageformat
   The /notify switch causes the executor to do queue "@notify me" after all the rows are processed. Note that this is the object running "@mapsql", and not <obj>.
 
   The /colnames switch causes @mapsql to first queue the obj/attr with row number (%0) set to 0 and args %1 to v(29) being the column names.
-  
+
   By default, the object using @mapsql will be the enactor (%#) for the triggered attribute. However, if you control <object>, the /spoof switch can be used to preserve the current enactor.
-  
+
   Examples:
     > &desctable me=think align(30 20 4 10 10,%0,%1,%2,%3,%4)
     > @mapsql me/desctable=DESCRIBE table_name
-    
+
     > &showresult me=@pemit %#=%0. [r(name, arg)] ([r(age, arg)])
     > @mapsql me/showresult=SELECT `name`, `age` FROM `people`
 
@@ -2768,11 +2768,11 @@ See also: sql(), sqlescape(), mapsql(), @mapsql
   @startup <object>[=<action list>]
 
   Sets the list of actions on <object> that will happen whenever the MUSH is restarted. This lets you start up objects that need to be running continuously. It is also useful for setting up @functions and @hooks, which are not saved across restarts.
-  
+
   @startup is also triggered when an object is @restarted or @undestroyed.
-  
+
   Note that @startups are NEVER inherited from parent objects.
-  
+
 See also: @restart, @undestroy, ACTION LISTS, @function, @command, @hook
 & @stats
   @stats [<player>]
@@ -2791,9 +2791,9 @@ See also: @restart, @undestroy, ACTION LISTS, @function, @command, @hook
   In the remaining forms, display statistics or histograms about the chunk (attribute) memory system.
 & @sweep
   @sweep [connected | here | inventory | exits ]
- 
+
   @sweep gives you a list of all nearby objects that are listening, including the room you are in and the objects you are carrying. Most objects only listen for a particular string or phrase, so they normally do not pose a problem if you need privacy. You will have to be careful of players and puppets since they will hear everything you say and do. (And might post the same to r.g.m!) AUDIBLE exits are also shown on an ordinary sweep, if the room is also AUDIBLE. (Audible exits aren't active unless the room is audible).
- 
+
   The four command options can also be used as switches (i.e., you can use "@sweep/connected" instead of "@sweep connected"). If the connected flag is given, only connected players and puppets owned by connected players will be shown in the @sweep. The "here" and "inventory" flags check only your location or inventory, respectively. "exits" only checks for AUDIBLE exits.
 
 See also: @scan
@@ -2801,16 +2801,16 @@ See also: @scan
 & @select
   @switch[/<switch>] <string>=<expr1>, <action1> [,<exprN>, <actionN>]... [,<default>]
   @select <string>=<expr1>, <action1> [,<exprN>, <actionN>]... [,<default>]
-  
+
   For those of you familiar with programming, these command acts like if/then/else or switch/case. It compares <string> against whatever each <expr> evaluates to. If <string> and <expr> match, the action list associated with that <expr> is carried out. If no match is found, the <default> action list is carried out. @switch runs <action>s for all matching <expr>s by default, while @select only runs the <action> for the first matching <expr>.
 
   If <expr> is a regexp or a wildcard glob, then $0-$9 will be set with capture data. (In wildcard globbing, every wildcard captures.)
 
   The string "#$" in <action>'s will be replaced with the evaluated result of <string> before it is acted on. Note that this replacement happens BEFORE the <action> is queued and executed, and does not work well in nested switches. It is recommended that you use the %$N substitution, or the stext() function, instead.
-  
+
   @switch/all runs <action>s for all matching <expr>s. Default for @switch.
   @switch/first runs <action> for the first matching <expr> only. Same as @select, and often the desired behaviour.
-  @switch/notify queues "@notify me" after the last <action>. 
+  @switch/notify queues "@notify me" after the last <action>.
   @switch/inline runs all actions in place, instead of creating a new queue entry for them.
   @switch/regexp makes <expr>s case-insensitive regular expressions, not wildcard/glob patterns.
 
@@ -2821,13 +2821,13 @@ See also: @scan
    /nobreak:  @breaks in <action> do not effect to the calling action list
    /localize: q-registers are saved before each <action> is run, and restored after it completes
    /clearreg: q-registers are all reset before each <action> is run. Most useful when used in combination with /localize.
-              
+
   @switch/inplace is an alias for @switch/inline/nobreak/localize.
 
   See 'help @switch3' for examples.
 See also: SWITCH WILDCARDS, switch(), @if, @break, stext(), slev()
 & @switch3
-  Examples: 
+  Examples:
     > &SWITCH_EX thing=$foo *: @switch %0=*a*, :acks, *b*, :bars, :glurps
     > foo abc
     thing acks
@@ -2846,10 +2846,10 @@ See also: SWITCH WILDCARDS, switch(), @if, @break, stext(), slev()
     > &SWITCH_EX thing=$foo *: @switch %0=*a*,say Before: '$0'. After: '$1'
     > foo foobarbaz
     thing says, "Before: 'foob'. After: 'rbaz'
-    
+
   Continued in 'help @switch4'
 & @switch4
-  Examples: 
+  Examples:
     > &SWITCH_EX me=$foo *:think before ; @switch %0=1,think one ; think after
     > foo 1
     thing before
@@ -2866,13 +2866,13 @@ See also: SWITCH WILDCARDS, switch(), @if, @break, stext(), slev()
   @teleport/list[/<switches>] <object-list>=<destination>
 
   Teleports <object> to <destination>. <object> can be a player, thing or exit, and defaults to yourself. (Exits must be specified by dbref, things or players can be specified by name.) The destination must be either JUMP_OK or controlled by you, and you must either control <object> or <object>'s current location. Also, the destination, if a room, cannot be teleport-locked against <object>. Mortals cannot teleport HEAVY objects. If the destination is a room with a drop-to, <object> may go to the drop-to room instead.
-  
+
   If the /list switch is given, each object specified in <object-list> will be teleported to <destination> instead. Names containing spaces should be enclosed in "double quotes".
-  
+
   Admin and those with the tport_anything power can teleport an object even if they don't control it. Those with tport_anywhere can teleport objects to any destination. You can also teleport an exit to any room if you have the Open_Anywhere power.
 
   Privileged players who teleport a player to another player send them to the location of the target, unless the /inside switch is used, in which case they are sent to the inventory of the target.
-  
+
   Continued in 'help @teleport2.
 & @teleport2
   Teleporting to an exit works the same as using "goto". If you don't control the exit and don't have the tport_anywhere power, either you or <object> must be nearby the exit.
@@ -2902,16 +2902,16 @@ See also: JUMP_OK, NO_TEL, Z_TEL, @tport, @lock
   /inplace is an alias for /inline/localize/nobreak.
 
   The /match switch is explained in 'help @trigger2'
-  
+
   You must control <object>, or it must be Link_OK and you must have the same owner, to trigger an attribute on it.
-  
+
   The triggered attribute is queued - the new action list is not run instantly. The action list is executed by <object>, not by the object using @trigger.
-  
+
   Continued in 'help @trigger2'.
 & @trigger2
 
   By default, the object using @trigger will be the enactor (%#) for the triggered attribute. However, if you control <object>, the /spoof switch can be used to preserve the current enactor. This is useful for global commands with @a* verb attributes.
-  
+
   Q-registers set at the time @trigger is run will be copied and made available in the triggered attribute, unless the /clearregs switch is given.
 
   @trigger can execute obj/attrs that are $-commands or ^-listens. e.g:
@@ -2953,14 +2953,14 @@ See also: @include, ufun(), VERBS
   @ulock <object>[=<key>]
   @uunlock <object>
 
-  These commands set the Use lock for <object> to <key>, or clear the Use lock. They are deprecated, and should be replaced with 
+  These commands set the Use lock for <object> to <key>, or clear the Use lock. They are deprecated, and should be replaced with
 
     @lock/use <object>[=<key>]
   and
     @lock/use <object>
 
   The Use lock determines who is allowed to "use" the object or trigger any $-commands or ^-listens on the object.
-  
+
   To only lock who can use $-commands, use @lock/command. To only lock who can trigger ^-listens, use @lock/listen.
 
   Example: if I want everyone but Bob to be able to use my toy, I would "@lock/use toy=!*Bob". If I want only Bob to be able to use it, I would "@lock/use toy==*Bob".
@@ -2968,7 +2968,7 @@ See also: @include, ufun(), VERBS
 See also: @lock, use, locktypes
 & @uptime
   @uptime[/mortal]
-  
+
   This command, for mortals, gives the time until the next database dump. For wizards, it also gives the system uptime (just as if 'uptime' had been typed at the shell prompt) and process statistics, some of which are explained in the next help entry. Wizards can use the /mortal switch to avoid seeing the extra process statistics.
 
   Continued in 'help @uptime2'.
@@ -2990,38 +2990,38 @@ See also: @link, DROP-TO
 & @unlock
   @unlock[/<switch>] <object>
 
-  Removes the lock on <object>. It can take as many switches as @lock can. 
+  Removes the lock on <object>. It can take as many switches as @lock can.
 
 See also: @lock, locktypes
 & @version
   @version
 
   Tells the player the name of the MUSH, which version of the code is currently running on the system, when it was compiled, and when the last restart was. It may also include some other information, including the MUSH's website address and the GIT revision, if available.
-  
+
 See also: version(), numversion()
 & @verb
   @verb <victim>=<actor>,<what>,<whatd>,<owhat>,<owhatd>,<awhat>,<args>
-  
+
   This command provides a way to do user-defined verbs with associated @attr/@oattr/@aattr groups. Invoking it does the following:
-  
+
   <actor> sees the contents of <victim>'s <what> attribute, or <whatd> if <victim> doesn't have a <what>.
   Everyone in the same room as <actor> sees the contents of <victim>'s <owhat> attribute, with <actor>'s name prepended, or <owhatd>, also with <actor>'s name prepended, if <victim> doesn't have an <owhat>.
   <victim> executes the contents of his <awhat> attribute.
-  
+
   By supplying up to 29 <args>, you may pass those values on the stack (i.e. %0, %1, %2, etc. up through %9, and r(0,args) to r(29,args)).
-  
+
   Continued in 'help @verb2'.
 & @verb2
   In order to use this command, at least one of the following criterion must apply:
     1. The object which did the @verb is a wizard.
     2. The object which did the @verb controls both <actor> and <victim>
     3. The thing which triggered the @verb (such as through a $-command on the object which did the @verb) must be <actor>, AND the object which did the @verb must be either privileged or control <victim> or <victim> must be VISUAL.
-  
+
   See 'help @verb3' for examples.
 See also: USER-DEFINED COMMANDS, STACK, VERBS, @trigger
 & @verb3
   Examples:
-  
+
   > &VERB_EXAMPLE Test Object=$test:@verb me=%#,TEST,You just tested.,OTEST,just tested the example.,ATEST,%n
   > test
   You just tested.
@@ -3037,10 +3037,10 @@ See also: USER-DEFINED COMMANDS, STACK, VERBS, @trigger
 
   See 'help @verb4' for another example.
 & @verb4
-  In order to make this into a global command that anyone can use, we need to put it on a WIZARD object in the Master Room. 
+  In order to make this into a global command that anyone can use, we need to put it on a WIZARD object in the Master Room.
 
   > &DO_TEST Global=$test *: @assert setr(0,locate(%#,%0,n))=@pemit %#=I don't see that here. ; @verb %q0=%#, TEST, You test [capstr(%0)]., OTEST,tests [capstr(%0)]. ,ATEST
- 
+
   > &TEST Example=You test this fun example.
   > &ATEST Example=POSE has been tested!
   > test example
@@ -3053,11 +3053,11 @@ See also: USER-DEFINED COMMANDS, STACK, VERBS, @trigger
   @wait[/until] <object>/<time>=<command_list>
 
   The basic form of this command puts the command list (a semicolon-separated list of commands) into the wait queue to execute in <time> seconds. If the /until switch is given, the time is taken to be an absolute value in seconds, not an offset.
-  
+
   The second form sets up a semaphore wait on <object>. The enactor will execute <command_list> when <object> is @notified.
-  
+
   The third form combines the first two: the enactor will execute <command_list> when <object> is @notified or when <time> passes, whichever happens first.
- 
+
   More forms that support semaphores on arbitrary attributes are described in 'help @wait2'.
 
 See also: SEMAPHORES, @drain, @notify
@@ -3065,7 +3065,7 @@ See also: SEMAPHORES, @drain, @notify
   Normally, a semaphore wait depends on the SEMAPHORE attribute of the object in question. However, it is useful to be able to use other attributes as semaphores, so one object can be used as the blocker for multiple different things at once. Possible attribute names aren't completely arbitrary. See 'HELP SEMAPHORES5' for details.
 
   The syntax for these are:
- 
+
   @wait <object>/<attribute>=<command list>
   @wait[/until] <object>/<attribute>/<time>=<command list>
 
@@ -3088,9 +3088,9 @@ See also: SEMAPHORES, @drain, @notify
   @wizwall[/emit][/noeval] <message>
 
   @wall sends <message> to all connected players. @rwall only sends the message to connected wizards and royalty, and @wizwall is seen only be wizards.
-  
+
   <message> can be prefixed with : or ; to pose or semi-pose it, respectively, or the /emit switch can be given to emit the message. If <message> begins with a " and the chat_strip_quote option is on, the " will be stripped.
-  
+
   The message is prefixed with the value of the wall_prefix, rwall_prefix or wizwall_prefix options, depending on the command used.
 
 See also: @wizwall, @rwall
@@ -3101,9 +3101,9 @@ See also: @wizwall, @rwall
 
   When an object is checked for warnings (via @wcheck by the owner, or automatically), only warnings which are set to be reported on the object will be reported. If no warnings are set on the object, the owner's warning settings will be used. When admin use @wcheck to check non-owned objects, their personal warnings are always used.
 
-  For a list of warnings, see 'help warnings list'. 
+  For a list of warnings, see 'help warnings list'.
   For examples, see 'help @warnings2'.
-  
+
 See also: @wcheck, NO_WARN
 & @warnings2
 
@@ -3122,7 +3122,7 @@ See also: @wcheck, NO_WARN
   Players who @set themselves NO_WARN will receive no warnings ever until they unset the flag.
 & @wcheck
   @wcheck <object>
-  @wcheck/all 
+  @wcheck/all
   @wcheck/me
 
   The first form of the command performs warning checks on a specific object. The player must own the object or be see_all. When the owner runs the command, the @warnings of the object are used to determine which warnings to give. If the object has no @warning's set, the @warnings of the owner are used. When a non-owner runs the command, the @warnings of the non-owner are used.
@@ -3139,15 +3139,15 @@ See also: @warnings, WARNINGS, NO_WARN
 
   To avoid being found this way, just do: @set me=UNFINDABLE
 
-  Example: 
+  Example:
     > @whereis Moonchilde
 
 See also: UNFINDABLE, loc()
 & @wipe
   @wipe <object>[/<attribute pattern>]
-  
+
   This command clears attributes from <object>, with the exception of attributes changeable only by wizards, and attributes not controlled by the object's owner (i.e. locked attributes owned by someone else). Only God may use @wipe to clear wiz-changeable-only attributes. The SAFE flag protects objects from @wipe.
- 
+
   If no <pattern> is given, this gets rid of all the attributes, with exceptions as given above. If <pattern> is given, it gets rid of all attributes which match that pattern. Note that the restrictions above still apply.
 
   When wiping an attribute that is the root of an attribute tree, all attributes in that tree will also be removed.
@@ -3155,9 +3155,9 @@ See also: UNFINDABLE, loc()
   @zemit[/silent|/noisy] <zone>=<message>
 
   Emits a message to all rooms in <zone>. You must have control <zone> in order to use this command.
-  
+
   The /silent switch suppresses the confirmation message, and /noisy causes it to be shown. With neither switch, the silent_pemit @config option determines whether or not the message is shown. The confirmation message is only shown if you are not in a room which would receive <message>.
-  
+
 See also: @nszemit, zemit(), zone(), zwho(), ZONES
 & ahelp
 & anews
@@ -3170,7 +3170,7 @@ See also: @nszemit, zemit(), zone(), zwho(), ZONES
   brief[/opaque] [<object>]
 
   This command works like an abbreviated version of "examine", showing information about an object including its name, owner, zone, type, flags and powers, locks, channels, warnings, home and location. Unlike "examine", it does not print out all the attributes on the object. It will include the contents of <object>, unless the /opaque switch is given.
-  
+
   <object> defaults to "here".
 
 See also: examine
@@ -3182,13 +3182,13 @@ See also: examine
   cv <name> <password>
 
   Not really MUSH commands, but commands available at the connect screen. Wizards can use 'cd' instead of 'connect'; the new connection will be hidden (as per @hide), and the player will be set DARK. Mortals set HEAR_CONNECT will not hear dark wizards connect.
-  
+
   Wizards, Royalty, and those with the Hide @power can use 'ch' to connect with the new connection hidden (as per @hide).
-  
+
   Connecting using 'cv' causes the Dark flag to be cleared prior to connection messages being broadcast.
-  
+
   None of those commands affect the hidden status of other connections, if you're reconnecting.
-  
+
 See also: DARK, @hide
 & OUTPUTPREFIX
 & OUTPUTSUFFIX
@@ -3201,14 +3201,14 @@ See also: DARK, @hide
   IDLE [<string>]
 
   This command does nothing. It does not reset a connection's idle time. It is useful for people who are connecting from behind a NAT gateway with a short fixed timeout; if you're in this situation, have your client send the IDLE command every minute or so, and the NAT connection won't time out (but you won't appear, to other players, to be active).
-  
+
   Some routers will only consider a connection alive if text is received, as well as sent. If you give a <string> with the IDLE command, that same <string> will be sent back to you for this purpose.
-  
+
 See also: KEEPALIVE, @idle
 & teach
   teach <command>
   teach/list <action list>
-  
+
   The teach command shows its argument (unparsed) to others in your location, and then executes it as a command. If the /list switch is given, it will run an <action list> of commands in much the same way as @triggering an attribute. Otherwise, it executes a single <command>, exactly as if you'd entered <command> from your client. Useful for helping newbies and demonstrating commands.
 
     > say To do a pose, use :<action>
@@ -3220,7 +3220,7 @@ See also: KEEPALIVE, @idle
     > teach "[sort(c b a)]
     Javelin types --> "[sort(c b a)]
     Javelin says, "a b c"
-  
+
     > teach/list @switch 1=1, say Third; say First; @break 1; say Second
     Javelin types --> @switch 1=1, say Third; say First; @break 1; say Second
     You say, "First"
@@ -3230,7 +3230,7 @@ See also: @trigger, @include
 & drop
   drop <object>
 
-  Drops <object>, if you are presently carrying it. If the room the object is dropped in has a DROP-TO set, the object may automatically be sent to another location. 
+  Drops <object>, if you are presently carrying it. If the room the object is dropped in has a DROP-TO set, the object may automatically be sent to another location.
 
   In order to drop an object, you must pass it's Drop lock and your location's DropIn lock.
 
@@ -3244,16 +3244,16 @@ See also: empty, get, STICKY, DROP-TO
 
 See: @enter, @efail, @ealias, leave, @lock, @idescribe, INTERIORS
 & examine
-  examine[/<switches>] <object>[/<attribute>] 
-  
-  Displays all available information about <object>. <object> may be an object, 'me' or 'here'. You must control the object to examine it. If you do not own the object, or it is not visible, you will just see the name of the object's owner. May be abbreviated 'ex <object>'. If the attribute parameter is given, you will only see that attribute (good for looking at code). You can also wildcard match on attributes. 
+  examine[/<switches>] <object>[/<attribute>]
+
+  Displays all available information about <object>. <object> may be an object, 'me' or 'here'. You must control the object to examine it. If you do not own the object, or it is not visible, you will just see the name of the object's owner. May be abbreviated 'ex <object>'. If the attribute parameter is given, you will only see that attribute (good for looking at code). You can also wildcard match on attributes.
   The * wildcard matches any number of characters except a backtick (`).
   The ? wildcard matches a single character except a backtick (`).
   The ** wildcard matches any number of characters, including backticks.
   For example, to see all the attributes that began with a 'v' you could do ex <object>/v**
-  
+
   The /brief switch is equivalent to the 'brief' command.
-  The /debug switch is wizard-only and shows raw values for certain fields in an object. 
+  The /debug switch is wizard-only and shows raw values for certain fields in an object.
   The /mortal switch shows an object as if you were a mortal other than the object's owner and is primarily useful to admins. This switch ignores the object's VISUAL flag (but not its attribute flags)
   The /parent switch show attributes that would be inherited from the object's parents, if you have permission to examine the attributes on the parent.
   The /all switch shows the values of VEILED attributes.
@@ -3276,7 +3276,7 @@ See also: follow, unfollow, desert, followers()
 & desert
   desert <object>
   desert
- 
+
   The desert command stops <object> from following you and stops you from following <object>. That is, it's shorthand for 'unfollow <object>' and 'dismiss <object>'. If no object is given, it stops everyone from following or leading you.
 
 See also: follow, unfollow, dismiss, followers(), following()
@@ -3294,11 +3294,11 @@ See also: get, drop
   get <box>'s <object>
 
   The first form of this command lets you pick up <object> from your current location. The second form allows you to take <object> from inside <box>'s inventory.
-  
+
   In both cases, you must pass <object>'s Basic @lock, and the @lock/take of it's location.
-  
+
   To get an object from someone else's inventory, the possessive_get @config option must be true (and, if <box> is a disconnected player, so must possessive_get_d). <box> must also be set ENTER_OK.
-  
+
   'take' is usually an alias for the 'get' command.
 
 See also: @lock, ENTER_OK, give, drop, @success, inventory
@@ -3308,7 +3308,7 @@ See also: @lock, ENTER_OK, give, drop, @success, inventory
   @buy <object>[=<message>]
   @obuy <object>[=<message>]
   @abuy <object>[=<message>]
-  
+
   These attributes contain the message shown to a player who successfully buys something from <object> using the "buy" command, the message shown to others in the room when something is bought from <object> (prefixed with the buyer's name), and the actions to be taken by <object> when something is bought from it, respectively. Each attribute is passed the item being purchased as %0 and the amount paid for it as %1.
 
   Example:
@@ -3321,11 +3321,11 @@ See also: buy, @pricelist, MONEY, @lock, VERBS, @cost, give
   @pricelist <object>=<item1>:<price1>[,<price2>][ <item2>:...]
 
   The PRICELIST attribute is a space-delimited list of item names and prices that are checked when the 'buy' command is run.
-  
+
   An item name may have '_'s where the player would use a space in the name.
 
   A price is either a number (20), a range of numbers (10-30), or a minimum number (10+). An item can also have several different prices, separated by commas.
-  
+
   A player must pass <object>'s @lock/pay in order to purchase from it.
 
   Example::
@@ -3355,14 +3355,14 @@ See also: @BUY, @PRICELIST, give, @COST
   give <object> to <recipient>
 
   The first two forms of this command give <number> pennies to <recipient>. If <recipient> is a non-player, it must have an @COST, and any pennies given to it will go to its owner. The amount given must match <recipient>'s @cost (if set). If /silent is given, the message informing the recipient how many pennies were given is suppressed. Wizards may "give" a negative number of pennies to take from players. When you give <recipient> pennies, his PAYMENT/OPAYMENT/APAYMENT attributes are triggered. You must pass <recipient>'s @lock/pay, unless you are a Wizard and are either giving a negative number of pennies, or giving to a player with no @cost.
-  
+
   The last two forms of this command give an <object> from your inventory to <recipient>. The recipient must be set ENTER_OK, and you must pass his @lock/from. You must also pass <object>'s @lock/give, and <object> must pass <recipient>'s @lock/receive. When you give an object successfully, your GIVE/OGIVE/AGIVE attributes, <recipient>'s RECEIVE/ORECEIVE/ARECEIVE attributes, and <object>'s SUCCESS/ASUCCESS/OSUCCESS attributes are all triggered.
 
 See also: @pay, @cost, @lock, inventory, @receive, @give, buy, @success
 & go
 & goto
 & move
-  go[to] <direction> 
+  go[to] <direction>
   go[to] home
   move <direction>
   move home
@@ -3376,7 +3376,7 @@ See also: HOME, @link, @ealias, @lalias, EXITS
   INFO
 
   This command returns some information about the MUSH you are on, such as its version number, time of last restart, number of players currently connected, and size of database. It can be issued from the connect screen.
-  
+
 See also: MSSP-REQUEST
 & inventory
   inventory
@@ -3384,7 +3384,7 @@ See also: MSSP-REQUEST
   Lists what you are carrying. Can be abbreviated by just 'i', or 'inv'. It also tells you how much MUSH money you have. If you are not set OPAQUE, others will also be able to see what is in your inventory by looking at you.
 
   Note that on some MUSHes it is possible to take things that are in someone else's inventory. To be safe, @lock any objects that you do not want to lose.
-  
+
 See also: score, take, drop, OPAQUE, @lock, @invformat
 & leave
   leave
@@ -3393,7 +3393,7 @@ See also: score, take, drop, OPAQUE, @lock, @invformat
 
   The NO_LEAVE flag may be enabled on some MUSHes. Objects set with this flag cannot be left. @lock/leave may also be enabled on some MUSHes, which allows you to set who can leave the object. If you fail to leave, the object's @lfail/@olfail/@alfail messages/actions will be triggered.
 
-See also: enter, @leave, @lfail, @lalias, @lock, INTERIORS 
+See also: enter, @leave, @lfail, @lalias, @lock, INTERIORS
 & LOGOUT
   LOGOUT
 
@@ -3406,7 +3406,7 @@ See also: enter, @leave, @lfail, @lalias, @lock, INTERIORS
   look/outside [<object>]
 
   Displays the description of <object>, or the room you're in if you don't name a specific object. You can also look at objects inside others, as long as the <container> is not set OPAQUE, or at objects on the other side of an exit, if the exit is set TRANSPARENT or CLOUDY.
-  
+
   If you're inside a container, look/outside allows you to look at the room the container is in, or at other objects in your container's location, as long as your container is not set OPAQUE.
 
   Continued in 'help look2'.
@@ -3414,11 +3414,11 @@ See also: enter, @leave, @lfail, @lalias, @lock, INTERIORS
   If you look at an object that is not set OPAQUE, you will see any non-DARK items in its inventory. You can look at DARK items in your location if you know what their name is by typing 'look <object>', but they will not show up in the list of contents.
 
   When you type 'look' alone, you look at your current location. For a room, this normally shows you the room's description, the list of contents, and any obvious exits from the room. For an object, it shows you the interior description (@idescribe) instead, if one is set.
-  
+
   If a room is set DARK, when you look you will not see any of the exits or contents of the room, unless they are set LIGHT.
 
   'look' may be abbreviated 'l', and is sometimes aliased as 'read'.
-  
+
 See also: OPAQUE, FLAGS, @describe, @adescribe, @odescribe, DARK, LIGHT, TRANSPARENT, CLOUDY
 & news
   news [<topic>]
@@ -3453,7 +3453,7 @@ See also: OPAQUE, FLAGS, @describe, @adescribe, @odescribe, DARK, LIGHT, TRANSPA
   The /noeval switch prevents the MUSH from evaluating the message.
   The /override switch is admin-only, and overrides pagelocks and HAVEN.
   The /port switch is admin-only, and will page a single port descriptor directly, including connections that have not yet logged into a player.
-  
+
 See also: @lock, @alias, @pageformat, pose, :, ;, HAVEN, NOSPOOF, FLAGS
 & :
 & ;
@@ -3465,19 +3465,19 @@ See also: @lock, @alias, @pageformat, pose, :, ;, HAVEN, NOSPOOF, FLAGS
   pose/nospace[/noeval] <action>
   semipose[/noeval] <action>
   ;<action>
- 
+
   The pose and semipose commands allow you to perform actions. Pose shows your name, a space, and then <action>; semipose omits the space. They can be abbreviated to ':' and ';' respectively. The /noeval switch stops <action> from being evaluated.
-  
+
   If you have a SPEECHMOD attribute set, it will be evaluated with <action> as %0 and either : (for pose) or ; (for semipose) as %1. The result is used instead of <action>, as long as it returns a non-empty string.
 
   See 'help pose2' for examples.
 See also: say, @emit, @speechmod
 & pose2
- 
+
   Examples:
     > pose waves.
     Bob waves.
-    
+
     > :laughs out loud.
     Bob laughs out loud.
     > ;'s laughing on the inside.
@@ -3488,17 +3488,17 @@ See also: say, @emit, @speechmod
   "<message>
 
   Says <message> out loud. The message will be enclosed in double-quotes. A single double-quote is the abbreviation for this common command. If the /noeval switch is given, <message> will not be evaluated.
-  
+
   If you have a SPEECHMOD attribute set, it will be evaluated with <message> passed as %0 and " (a double-quote) passed as %1. The result is shown instead of <message>, as long as it evaluates to a non-empty string.
-  
+
   If <message> begins with a double-quote and the chat_strip_quote @config option is on, the leading " will be stripped.
 
 See also: pose, whisper, @speechmod, @emit, page
 & score
   score
-  
+
   Displays how many pennies you have. Helpful to see if any machines are looping. If they are, your pennies will be being rapidly drained. MUSH money may also be used for other purposes in the game.
-  
+
 See also: LOOPING, @ps, QUEUE, MONEY, TRACK_MONEY
 & think
   think <message>
@@ -3523,7 +3523,7 @@ See also: follow, dismiss, desert, followers(), @follow, @ofollow, @afollow
   use <object>
 
   This command attempts to "use" <object>. If you do not pass <object>'s @lock/use, the UFAIL/OUFAIL/AUFAIL attributes are triggered.
-  
+
   If you pass the lock, you will see <object>'s USE attribute, and others in your location will see <object>'s OUSE. Depending on <object>'s CHARGES attribute, one of <object>'s AUSE or RUNOUT attributes will be triggered - see 'help @charges' for more information.
 
 See also: @use, @charges, @lock, @ufail
@@ -3532,20 +3532,20 @@ See also: @use, @charges, @lock, @ufail
   This internal command is run when someone attempts to run a command which starts with a function, for example:
     &test me=$test: [emit(test)]
   By default it sends the owner of the offending object a message, so they can fix the code to use a command instead of a function. The command must be enabled (either in restrict.cnf or with @command/enable) in order to be used. It can be @hooked to set custom behaviour.
-  
+
   Example:
     > @hook/override warn_on_missing=#0, wom
     > &wom #0=$warn_on_missing: @pemit/list %# [owner(%!)]=[name(%!)] has broken code in %=!
-         
+
     > &wom #0=$warn_on_missing *: @pemit [owner(%!)]=[name(%!)] has broken code in %= - attempted to run %0!
-         
+
 See also: huh_command, unimplemented_command
 & UNIMPLEMENTED_COMMAND
 
   This internal command is run when someone attempts to use an unimplemented command. Currently, this only occurs when a command has been added with @command/add but has not been properly @hooked to run softcode. UNIMPLEMENTED_COMMAND cannot be run directly.
-  
+
   By default, the command just shows the message "This command has not been implemented.", but you can @hook it to perform other actions.
-  
+
 See also: huh_command, warn_on_missing, @command, @hook
 & whisper
   whisper <player>=<message>
@@ -3555,11 +3555,11 @@ See also: huh_command, warn_on_missing, @command, @hook
   whisper/list <players>=<message>
 
   Whispers the message to the named person, if they are nearby. If <message> is prefixed with a ':' or ';' it will be posed or semiposed, respectively.
-  
+
   With the /noisy switch, other players in the room may be informed who you whisper to (but not what you whisper); the probability that a noisy whisper will be heard is set by the 'whisper_loudness' @config option. With the /silent switch, the whisper will not be overheard. (When neither switch is given, the default behaviour is controlled by the 'noisy_whisper' @config option.)
 
   <message> will not be evaluated if the /noeval switch is given.
-  
+
   The /list switch lets you whisper to multiple people at once. In this case, <players> is a space-separated list of names, and names with spaces should be enclosed in double-quotes, as per page/list.
 
 See also: page, pose, @pemit
@@ -3567,25 +3567,25 @@ See also: page, pose, @pemit
 & DOING
   WHO [<pattern>]
   DOING [<pattern>]
-  
+
   For mortals, the WHO command displays a list of players currently connected to the MUSH, the amount of time they've been connected, their idle time, and their @doing. Hidden players are not shown.
-  
+
   For admin, WHO shows the names of online players, their location, connection/idle times, the number of commands typed through the connection, the descriptor/port number, and the host the player is connected from. It also includes hidden players, and connections which are at the login screen, but have not yet connected to a player.
-  
+
   Admin can use the DOING command to see the same output mortals see with WHO, with the exception that dark/hidden players are included.
-  
+
   If a <pattern> is given for either command, only connected players whose names start with <pattern> are shown. If <pattern> is a wildcard, only players whose names or aliases match the pattern are shown.
-  
+
   Continued in 'help who2'.
 & WHO2
 
   In earlier versions of PennMUSH, WHO was a socket command (meaning only players could use it, and that while it could not be overwritten, you could use softcoded 'who' commands along side it which worked as long as they weren't typed in all upper-case). Existing games which have softcoded 'who' commands can maintain this feature by using an @hook/ignore on the WHO command, such as:
-  
+
     > &HOOK.WHO <object>=not(comp(left(%c,3),WHO))
     > @hook/ignore WHO=<object>,HOOK.WHO
 
   @hooks are not maintained across reboots, and should be placed into an @startup on a low-dbref object.
-  
+
   Note: The WHO command available at the login screen is totally separate from the in-game WHO command, and is not affected by any changes to the in-game WHO. To alter that, use the WHO_FILE @config option.
 
 See also: @doing, @poll, SESSION
@@ -3599,13 +3599,13 @@ See also: WHO
   with[/room] <obj>=<command>
 
   Attempts to run a user-defined command on a specific object. If the /room switch is given, <obj> must be a room or your current location, and its contents are checked for commands as if it was a master room.
-  
+
   <obj> must be an object near you, an object you control, your ZMO or (if the /room switch is given) the Master Room.
 
 See also: USER-DEFINED COMMANDS, EVALUATION ORDER
 & socket commands
   These commands can only be entered by a connected player through their client. They generally do things that only affect a specific connection and would be meaningless if run by an object or disconnected player.
-  
+
   IDLE    INFO    LOGOUT  OUTPUTPREFIX    OUTPUTSUFFIX
   PROMPT_NEWLINES QUIT    SCREENWIDTH     SCREENHEIGHT
   SOCKSET MSSP-REQUEST
@@ -3613,13 +3613,13 @@ See also: USER-DEFINED COMMANDS, EVALUATION ORDER
   In addition, the following commands can only be used at the login screen:
 
   cd ch cv connect create register
-  
+
   The WHO command can also be used at the login screen. Please note that this is different to the in-game WHO command.
 & MSSP-REQUEST
   MSSP-REQUEST
-  
+
   This socket command shows some basic information about the MUSH, along with any admin-defined information specified in mush.cnf with the 'mssp' option. The info is also shown via the MSSP telnet option. Useful for MUD crawlers and bots. For more information about the MUD Server Status Protocol (MSSP), see http://tintin.sourceforge.net/mssp/
-  
+
 See also: INFO
 & @SUGGEST
 @suggest[/list]

--- a/hdrs/mushtype.h
+++ b/hdrs/mushtype.h
@@ -224,6 +224,9 @@ struct text_queue {
  * the MUSH is running in
  */
 #define CONN_STRIPACCENTS 0x80
+/** Socket receives QUOTA_NAX every refresh. */
+#define CONN_NOQUOTA 0x160
+
 /** Default connection, nothing special */
 #define CONN_DEFAULT (CONN_PROMPT_NEWLINES | CONN_AWAITING_FIRST_DATA)
 /** Bits reserved for the color style */


### PR DESCRIPTION
Adds NOQUOTA @sockset command.
Persists --disable-socket-quota command line option through reboots.

Closes #1275 

I'm 50/50 on the whole NOQUOTA versus refreshing max quota every refresh. I feel like this is the safer way, but open to changing it to just ignore the quota entirely.
 Mike/Raev?
