### PR TITLE
Change fixed width format for names in dump_users()

### DIFF
--- a/src/bsd.c
+++ b/src/bsd.c
@@ -5412,7 +5412,7 @@ dump_users(DESC *call_by, char *match)
     if (nlen < 16)
       safe_fill(' ', 16 - nlen, nbuff, &np);
     *np = '\0';
-    snprintf(tbuf, sizeof tbuf, "%16.16s %10.10s %6.6s%c %s", nbuff,
+    snprintf(tbuf, sizeof tbuf, "%s %10.10s %6.6s%c %s", nbuff,
              onfor_time_fmt(d->connected_at, 10),
              idle_time_fmt(d->last_time, 4), (Dark(d->player) ? 'D' : ' '),
              get_doing(d->player, NOTHING, NOTHING, NULL, 0));


### PR DESCRIPTION
The printf format for names in bsd.c: dump_users() was using a fixed width '%16.16s' format even though monikers with ansi may have more than 16 characters with unprintable ansi codes. Changed the format to '%s' since we are manually padding with spaces up to 16.