### PR TITLE
Better pidfile

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -52,6 +52,7 @@ Minor Changes
 * @command/restrict will only clear the failure message if a new one is supplied. [MT]
 * @SOCKSET now has a NOQUOTA option which causes that socket to be given the max command input quota per refresh. [MT]
 * --disable-socket-quota is now preserved across reboots. [MT]
+* Improved detection of an already running game. [SW]
 
 Softcode
 --------

--- a/config.h.in
+++ b/config.h.in
@@ -65,6 +65,8 @@
 
 #undef HAVE_PTHREAD_H
 
+#undef HAVE_SYS_FILE_H
+
 /* C99ish headers. The first two are really really nice to have. */
 
 #undef HAVE_STDINT_H
@@ -279,6 +281,8 @@ typedef bool _Bool;
 #undef HAVE_WRITEV
 
 #undef HAVE_FCNTL
+
+#undef HAVE_FLOCK
 
 #undef HAVE_INOTIFY_INIT1
 

--- a/configure
+++ b/configure
@@ -714,6 +714,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -814,6 +815,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1066,6 +1068,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1203,7 +1214,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1356,6 +1367,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -7160,18 +7172,19 @@ fi
 
 done
 
-for ac_header in sys/ucred.h
+for ac_header in sys/ucred.h sys/file.h
 do :
-  ac_fn_c_check_header_compile "$LINENO" "sys/ucred.h" "ac_cv_header_sys_ucred_h" "
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "
 $ac_includes_default
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
 
 "
-if test "x$ac_cv_header_sys_ucred_h" = xyes; then :
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_SYS_UCRED_H 1
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
 _ACEOF
 
 fi
@@ -10309,7 +10322,7 @@ _ACEOF
 fi
 done
 
-for ac_func in fcntl poll kqueue inotify_init1
+for ac_func in fcntl flock poll kqueue inotify_init1
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.in
+++ b/configure.in
@@ -147,7 +147,7 @@ AC_CHECK_HEADERS([netinet/in.h sys/un.h sys/resource.h sys/event.h sys/uio.h])
 AC_CHECK_HEADERS([poll.h sys/select.h sys/inotify.h langinfo.h crypt.h])
 AC_CHECK_HEADERS([event2/event.h event2/dns.h fenv.h sys/param.h])
 AC_CHECK_HEADERS([sys/prctl.h byteswap.h endian.h sys/endian.h pthread.h])
-AC_CHECK_HEADERS([sys/ucred.h], [], [], [
+AC_CHECK_HEADERS([sys/ucred.h sys/file.h], [], [], [
 AC_INCLUDES_DEFAULT
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
@@ -263,7 +263,7 @@ fi
 AC_CHECK_FUNCS([cbrt log2 lrint imaxdiv hypot])
 AC_CHECK_FUNCS([getuid geteuid seteuid getpriority setpriority])
 AC_CHECK_FUNCS([socketpair sigaction sigprocmask writev])
-AC_CHECK_FUNCS([fcntl poll kqueue inotify_init1])
+AC_CHECK_FUNCS([fcntl flock poll kqueue inotify_init1])
 AC_CHECK_FUNCS([pread pwrite eventfd pledge pipe2])
 AC_CHECK_FUNCS([fetestexcept feclearexcept])
 AX_FUNC_POSIX_MEMALIGN

--- a/game/restart.dst
+++ b/game/restart.dst
@@ -112,11 +112,20 @@ fi
 # if [ "$mush" -gt 0 ]; then
 
 # New style, look for a pid file.
-if [ -f "$PIDFILE" ]; then
+if [ -x /usr/bin/flock ]; then
+    # On linux, use flock(1) to see if the file is locked.
+    /usr/bin/flock -E 5 -n "$PIDFILE" -c true
+    if [ $? -eq 5 ]; then
+        mush=0
+    else
+        mush=1
+    fi
+elif [ -f "$PIDFILE" ]; then
+    # Otherwise see if the process listed in the file is running.
     kill -0 $(cat "$PIDFILE") 2>/dev/null
     mush=$?
 else
-    mush=1;
+    mush=1
 fi
 
 if [ "$mush" -eq 0 ]; then


### PR DESCRIPTION
Currently, we try to prevent multiple copies of a game from running by having the mush process create a file with its process id, and the restart script checking to see if a process with that pid is running. This has a bunch of race conditions and other issues.

This patch tries to address the worst of them by having the mush, after creating the pid file, acquire a lock on it, and exiting with a helpful failure message if it can't. That way even if two restart's are run at the same time, only one copy of the game will actually start up no matter what.

It also tweaks restart to use [flock(1)](http://man7.org/linux/man-pages/man1/flock.1.html) to check to see if a game is running, when available. (Linux, possibly other OSes), which fixes an issue where the mush isn't running but something else is using the pid recorded in the file.

(Ultimately I think it's probably desirable to remove the restart script completely but that's another project)