### PR TITLE
Use syslog for logging

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -53,6 +53,7 @@ Minor Changes
 * @SOCKSET now has a NOQUOTA option which causes that socket to be given the max command input quota per refresh. [MT]
 * --disable-socket-quota is now preserved across reboots. [MT]
 * Improved detection of an already running game. [SW]
+* Support logging through the OS syslog facility. [SW]
 
 Softcode
 --------

--- a/config.h.in
+++ b/config.h.in
@@ -77,6 +77,8 @@
 
 #undef HAVE_FENV_H
 
+#undef HAVE_SYSLOG_H
+
 /* Libraries */
 
 #undef HAVE_MYSQL
@@ -335,6 +337,8 @@ typedef bool _Bool;
 #undef HAVE_ARC4RANDOM_BUF
 
 #undef HAVE_PTHREAD_ATFORK
+
+#undef HAVE_SYSLOG
 
 /* Bunch of sqlite3 stuff */
 

--- a/configure
+++ b/configure
@@ -7146,7 +7146,7 @@ fi
 
 done
 
-for ac_header in event2/event.h event2/dns.h fenv.h sys/param.h
+for ac_header in event2/event.h event2/dns.h fenv.h sys/param.h syslog.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -10334,7 +10334,7 @@ _ACEOF
 fi
 done
 
-for ac_func in pread pwrite eventfd pledge pipe2
+for ac_func in pread pwrite eventfd pledge pipe2 syslog
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.in
+++ b/configure.in
@@ -145,7 +145,7 @@ AC_CHECK_HEADERS([sys/stat.h sys/time.h sys/types.h sys/eventfd.h])
 AC_CHECK_HEADERS([sys/socket.h arpa/inet.h libintl.h netdb.h netinet/tcp.h])
 AC_CHECK_HEADERS([netinet/in.h sys/un.h sys/resource.h sys/event.h sys/uio.h])
 AC_CHECK_HEADERS([poll.h sys/select.h sys/inotify.h langinfo.h crypt.h])
-AC_CHECK_HEADERS([event2/event.h event2/dns.h fenv.h sys/param.h])
+AC_CHECK_HEADERS([event2/event.h event2/dns.h fenv.h sys/param.h syslog.h])
 AC_CHECK_HEADERS([sys/prctl.h byteswap.h endian.h sys/endian.h pthread.h])
 AC_CHECK_HEADERS([sys/ucred.h sys/file.h], [], [], [
 AC_INCLUDES_DEFAULT
@@ -264,7 +264,7 @@ AC_CHECK_FUNCS([cbrt log2 lrint imaxdiv hypot])
 AC_CHECK_FUNCS([getuid geteuid seteuid getpriority setpriority])
 AC_CHECK_FUNCS([socketpair sigaction sigprocmask writev])
 AC_CHECK_FUNCS([fcntl flock poll kqueue inotify_init1])
-AC_CHECK_FUNCS([pread pwrite eventfd pledge pipe2])
+AC_CHECK_FUNCS([pread pwrite eventfd pledge pipe2 syslog])
 AC_CHECK_FUNCS([fetestexcept feclearexcept])
 AX_FUNC_POSIX_MEMALIGN
 

--- a/game/mushcnf.dst
+++ b/game/mushcnf.dst
@@ -600,6 +600,9 @@ colors_file txt/colors.json
 ### MUSH.
 ###
 
+# If true, also log messages to the system syslog service.
+use_syslog no
+
 # Filename to log important messages (startups, errors, shutdowns)
 error_log  log/netmush.log
 

--- a/hdrs/conf.h
+++ b/hdrs/conf.h
@@ -230,13 +230,14 @@ struct options_table {
                                         files */
   char guest_file[2][FILE_PATH_LEN]; /**< Names of text and html guest files */
   char who_file[2][FILE_PATH_LEN];   /**< Names of text and html who files */
-  char index_html[FILE_PATH_LEN];    /**< Name of the default HTTP landing page */
-  int log_commands;                  /**< Should we log all commands? */
-  int log_forces;                    /**< Should we log force commands? */
-  int support_pueblo;                /**< Should the MUSH send Pueblo tags? */
-  int login_allow;                   /**< Are mortals allowed to log in? */
-  int guest_allow;                   /**< Are guests allowed to log in? */
-  int create_allow;                  /**< Can new players be created? */
+  char index_html[FILE_PATH_LEN]; /**< Name of the default HTTP landing page */
+  int use_syslog;                 /**< Should we also log to syslog? */
+  int log_commands;               /**< Should we log all commands? */
+  int log_forces;                 /**< Should we log force commands? */
+  int support_pueblo;             /**< Should the MUSH send Pueblo tags? */
+  int login_allow;                /**< Are mortals allowed to log in? */
+  int guest_allow;                /**< Are guests allowed to log in? */
+  int create_allow;               /**< Can new players be created? */
   int reverse_shs; /**< Should the SHS routines assume little-endian byte order?
                     */
   char player_flags[BUFFER_LEN];  /**< Space-separated list of flags to set on

--- a/hdrs/log.h
+++ b/hdrs/log.h
@@ -8,6 +8,7 @@
 #define LOG_H
 
 #include <stdio.h>
+#include <stdarg.h>
 #include "bufferq.h"
 #include "mushtype.h"
 
@@ -20,6 +21,18 @@ enum log_type {
   LT_TRACE, /**< Debugging log */
   LT_CHECK, /**< No idea? */
   LT_HUH    /**< Logs of huh_command's */
+};
+
+/** Log levels. Used for syslog logging. */
+enum log_level {
+  MLOG_EMERG,   /**< MUSH is unusable */
+  MLOG_ALERT,   /**< action must be taken immediately */
+  MLOG_CRIT,    /**< critical conditions */
+  MLOG_ERR,     /**< error conditions */
+  MLOG_WARNING, /**< warning conditions */
+  MLOG_NOTICE,  /**< normal but significant condition */
+  MLOG_INFO,    /**< informational message */
+  MLOG_DEBUG    /**< debug-level message */
 };
 
 /** A logfile stream */
@@ -41,6 +54,11 @@ void reopen_logs(void);
 void WIN32_CDECL do_log(enum log_type logtype, dbref player, dbref object,
                         const char *fmt, ...)
   __attribute__((__format__(__printf__, 4, 5)));
+void do_rawlog_vlvl(enum log_type logtype, enum log_level loglevel,
+                    const char *fmt, va_list args);
+void WIN32_CDECL do_rawlog_lvl(enum log_type logtype, enum log_level loglevel,
+                               const char *fmt, ...)
+  __attribute__((__format__(__printf__, 3, 4)));
 void WIN32_CDECL do_rawlog(enum log_type logtype, const char *fmt, ...)
   __attribute__((__format__(__printf__, 2, 3)));
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -243,6 +243,7 @@ PENNCONF conftable[] = {
   {"chan_cost", cf_int, &options.chan_cost, 10000, 0, "chat"},
   {"noisy_cemit", cf_bool, &options.noisy_cemit, 2, 0, "chat"},
   {"chan_title_len", cf_int, &options.chan_title_len, 250, 0, "chat"},
+  {"use_syslog", cf_bool, &options.use_syslog, 2, 0, "log"},
   {"log_commands", cf_bool, &options.log_commands, 2, 0, "log"},
   {"log_forces", cf_bool, &options.log_forces, 2, 0, "log"},
   {"error_log", cf_str, options.error_log, sizeof options.error_log, 0, "log"},
@@ -646,8 +647,9 @@ CONFIG_FUNC(cf_priv)
 
   if (is_strict_integer(val)) {
     if (!from_cmd) {
-      do_rawlog(LT_ERR, "CONFIG: Option '%s' set to an integer. Please update "
-                        "to a list of values.",
+      do_rawlog(LT_ERR,
+                "CONFIG: Option '%s' set to an integer. Please update "
+                "to a list of values.",
                 opt);
     }
     *((privbits *) loc) = parse_integer(val);
@@ -934,8 +936,9 @@ config_set(const char *opt, char *val, int source, int restrictions)
         return 0;
       }
     } else {
-      do_rawlog(LT_ERR, "CONFIG: restrict_attribute %s requires a restriction "
-                        "(use 'none' for none)",
+      do_rawlog(LT_ERR,
+                "CONFIG: restrict_attribute %s requires a restriction "
+                "(use 'none' for none)",
                 val);
       return 0;
     }
@@ -1241,6 +1244,7 @@ conf_default_set(void)
   strcpy(options.trace_log, "");
   strcpy(options.wizard_log, "");
   strcpy(options.checkpt_log, "");
+  options.use_syslog = 0;
   options.log_commands = 0;
   options.log_forces = 1;
   options.support_pueblo = 0;
@@ -1491,8 +1495,9 @@ config_file_checks(void)
   for (cp = hash_firstentry(&local_options); cp;
        cp = hash_nextentry(&local_options)) {
     if (!(cp->flags & (CP_OVERRIDDEN | CP_OPTIONAL))) {
-      do_rawlog(LT_ERR, "CONFIG: local directive '%s' missing from cnf file. "
-                        "Using default value.",
+      do_rawlog(LT_ERR,
+                "CONFIG: local directive '%s' missing from cnf file. "
+                "Using default value.",
                 cp->name);
     }
   }

--- a/src/memcheck.c
+++ b/src/memcheck.c
@@ -296,12 +296,14 @@ del_check(const char *ref, const char *filename, int line)
   if (chk) {
     chk->ref_count -= 1;
     if (chk->ref_count < 0)
-      do_rawlog(LT_TRACE,
-                "ERROR: Deleting a check with a negative count: %s (At %s:%d)",
-                ref, filename, line);
+      do_rawlog_lvl(
+        LT_TRACE, MLOG_WARNING,
+        "ERROR: Deleting a check with a negative count: %s (At %s:%d)", ref,
+        filename, line);
   } else {
-    do_rawlog(LT_TRACE, "ERROR: Deleting a non-existant check: %s (At %s:%d)",
-              ref, filename, line);
+    do_rawlog_lvl(LT_TRACE, MLOG_WARNING,
+                  "ERROR: Deleting a non-existant check: %s (At %s:%d)", ref,
+                  filename, line);
   }
 }
 
@@ -333,11 +335,12 @@ log_mem_check(void)
 
   if (!options.mem_check)
     return;
-  do_rawlog(LT_TRACE, "MEMCHECK dump starts");
+  do_rawlog_lvl(LT_TRACE, MLOG_DEBUG, "MEMCHECK dump starts");
   for (chk = memcheck_head->links[0]; chk; chk = chk->links[0]) {
-    do_rawlog(LT_TRACE, "%s : %d", chk->ref_name, chk->ref_count);
+    do_rawlog_lvl(LT_TRACE, MLOG_DEBUG, "%s : %d", chk->ref_name,
+                  chk->ref_count);
   }
-  do_rawlog(LT_TRACE, "MEMCHECK dump ends");
+  do_rawlog_lvl(LT_TRACE, MLOG_DEBUG, "MEMCHECK dump ends");
 }
 
 /** Dump a representation of the memcheck skip list into a file, using the dot


### PR DESCRIPTION
Logs messages through `syslog()` as well as the usual log files.

Syslog supports logging messages at different priority levels; new function `do_rawlog_lvl()` includes that level. Used in a few places as a proof of concept.