### PR TITLE
Added Dockerfile for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:latest
+
+RUN apt-get update -y && apt-get install -y gcc build-essential zlib1g-dev \
+    libssl-dev libevent-dev pkg-config postgresql-client libpq-dev \
+    mariadb-client libmariadb-dev-compat libpcre3-dev \
+    icu-devtools
+
+ADD . /src
+
+WORKDIR /src
+
+RUN ./configure && make && make install && make portmsg


### PR DESCRIPTION
Pretty straightforward Dockerfile. I picked Debian because it is pretty lightweight compared to other distros, but not prone to libc challenges like Alpine. I managed most dependencies except icu-config, which now appears to be deprecated.

A multi-stage build that does user configuration, etc. is certainly possible. However, I don't know if it is worthwhile to remove the build infrastructure, which isn't terribly large as it is. I think a lot could be done with using environment variables to configure external state for DB, etc. 

It is failing two tests:

Running tests for json:
TEST FAILURE: json.string.5                                                   
  command: think json(string, accent(foo, f:o))
  result:  "foo"
  pattern: ^"f\\u00F6o"

TEST FAILURE: json.string.6                                                   
  command: think json_query(json(string,accent(foo,f:o)), unescape)
  result:  foo
  pattern: ^f\xF6o

::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::        

81 tests, 79 succeeded, 2 failed (0 expected failures)
failed tests:
  json.string.5, json.string.6