### PR TITLE
Hopefully fixes @mail going forward

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -73,3 +73,4 @@ Fixes
 * Fix a file descriptor leak caused by recent OpenSSL versions. [SW]
 * Added GAGGED restrictions that were missing from a few commands, including `@message` and the MUXcomm aliases. [MG]
 * Minor help updates, including clarification of what GAGGED blocks, suggested by Merit. [#1262, MG, MT]
+* Some fixes to extmail.c and chunk.c to fix @mail going forward. [GM]

--- a/hdrs/version.h
+++ b/hdrs/version.h
@@ -1,4 +1,4 @@
-#define VERSION "1.8.7"
+#define VERSION "1.8.8"
 #define PATCHLEVEL "0"
-#define PATCHDATE "[08/10/2018]"
-#define NUMVERSION 1008007000
+#define PATCHDATE "[??/??/2020]"
+#define NUMVERSION 1008008000


### PR DESCRIPTION
I don't have enough time to duplicate the issue in Penn to figure out if this is the actual cause and correct fix, but here's the what I'm figuring:

1) `chunk_read` doesn't null terminate. This probably doesn't impact anywhere else except mail.c since get_message might be the only one to assume it does? There's also a possibility that things are saved into chunks with null_terminator, pulled out with it, then saved again without it. Just plain ugh.
2) Replace all the `strcpy()`s in extmail.c with `mush_strncpy()`s. Also? Hate for the non-#defined numbers. 30, 50 instead of SENDER_LEN and SUBJECT_LEN, etc etc?

Thoughts on other possible causes:
1) Loading in one form of `@config chunk` and dumping in a separate might have been a cause?
2) Interplay between some particular `uncompress()/compress()`, `chunk_fetch()/chunk_create()` and `getstring()`, etc ...