### PR TITLE
Add --version option.

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -25,6 +25,7 @@ Minor changes
 
 * Sqlite updated to 3.32.1. [SW]
 * cJSON updated to 1.7.13 [SW]
+* New `--version` option to the netmush binary to display the version and exit.
 
 Fixes
 -----

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -556,7 +556,10 @@ main(int argc, char **argv)
     int n;
     for (n = 1; n < argc; n++) {
       if (argv[n][0] == '-') {
-        if (strcmp(argv[n], "--no-session") == 0)
+        if (strcmp(argv[n], "--version") == 0) {
+          printf("PennMUSH %s patchlevel %s\n", VERSION, PATCHLEVEL);
+          return EXIT_SUCCESS;
+        } else if (strcmp(argv[n], "--no-session") == 0)
           detach_session = 0;
         else if (strcmp(argv[n], "--disable-socket-quota") == 0) {
           disable_socket_quota = true;


### PR DESCRIPTION
Spurred by something on `<Hardcode>` a few days about about finding the version of a netmush binary.