### PR TITLE
1350: BUGFIX - Allow ansi code translation for json unescape.

### DIFF
--- a/src/funjson.c
+++ b/src/funjson.c
@@ -169,7 +169,7 @@ FUNCTION(fun_json_query)
     latin1 =
       utf8_to_latin1(cJSON_GetStringValue(json), -1, &len, 0, "json.string");
     for (c = latin1; *c; c += 1) {
-      if (!isprint(*c) && !isspace(*c)) {
+      if (!isprint(*c) && !isspace(*c) && !(*c == 0x1B)) {
         *c = '?';
       }
     }


### PR DESCRIPTION
This is related to the following ticket:
https://github.com/pennmush/pennmush/issues/1350