### PR TITLE
Add function: HTTP()

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -33,6 +33,10 @@ Fixes
 * `udefault` only accepted 12 arguments, not the documented 32. [MG]
 * MOGRIFY`FORMAT was not being passed the mogrified channel name from MOGRIFY`CHANNAME as it should. Reported by Xperta [MT]
 
+Softcode
+--------
+* `http()` for local small http calls. Patch by Mercutio.
+
 Version 1.8.8 patchlevel 0 Apr 20 2020
 ======================================
 

--- a/game/txt/hlp/penncmd.hlp
+++ b/game/txt/hlp/penncmd.hlp
@@ -1272,7 +1272,7 @@ See also: TRANSPARENT, @conformat, @nameformat, @descformat
 
   Note: The response body has the same 8k limit as other MUSH strings. Anything longer is truncated; this command is best used with APIs that provide short responses.
 
-See also: urlencode(), urldecode()
+See also: urlencode(), urldecode(), http()
 & @firstexit
   @firstexit <exit1>[, ... , <exitN>]
   

--- a/game/txt/hlp/pennfunc.hlp
+++ b/game/txt/hlp/pennfunc.hlp
@@ -6036,3 +6036,20 @@ See also: urlencode(), @http
   lZj9lZYz8qZKfX6YWWZ3SqbzNLyALlszAXcuyO1u7Vo=
 
 See also: digest()
+& HTTP()
+  http(<obj>/<attr>,<verb>,<URL>[,<data>])
+
+  Attempts to retrieve URL with a HTTP GET request, and upon doing so, evaluates <obj>/<attr>. The body of the reply from the remote web server is passed as %0, with the HTTP status in %q<status> and the Content-Type header in %q<content-type>. If it runs into an error trying to create the request, it stores it in %q<http-error>.
+
+  The verb can be any of: POST, GET, PUT or DELETE, defaulting to GET. With these, the 'content-type' q-register controls the type of data; it defaults to 'application/x-www-form-urlencoded'.` If it contains the string "charset=utf-8", <data> will be converted to UTF-8, otherwise it is assumed to be Latin-1.
+
+  If the q-register 'userpass' is set when running @http, it should hold a string of the form user:password and will be used if needed for HTTP authentication.
+
+  It is recommended to use @http instead of http() for any remote or long calls, as http() runs with a connection timeout equal to half the time limit of a function call.
+
+  Restricted to objects set Wizard or with the Can_HTTP @Power.
+
+  Note: The response body has the same 8k limit as other MUSH strings. Anything longer is truncated; this command is best used with APIs that provide short responses.
+
+See also: urlencode(), urldecode(), @http
+

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -1204,9 +1204,11 @@ handle_curl_msg(CURLMsg *msg)
       if (resp->too_big) {
         notify(resp->thing, "Too much HTTP data received; excess truncated.");
       }
+
       queue_attribute_base_priv(resp->thing, resp->attrname, resp->enactor, 0,
                                 resp->pe_regs, resp->queue_type, resp->thing,
                                 NULL, NULL);
+
     } else {
       notify_format(resp->thing, "Request failed: %s",
                     curl_easy_strerror(msg->data.result));
@@ -1517,8 +1519,7 @@ check_sockets(uint32_t msec_timeout)
   }
 
 #ifdef HAVE_LIBCURL
-  curl_status =
-    curl_multi_wait(curl_handle, fds, fds_used, msec_timeout, &found);
+  curl_status = curl_multi_wait(curl_handle, fds, fds_used, msec_timeout, &found);
 
   if (curl_status != CURLM_OK) {
     do_rawlog(LT_ERR, "curl_multi_wait: %s", curl_multi_strerror(curl_status));

--- a/src/cmds.c
+++ b/src/cmds.c
@@ -1982,8 +1982,7 @@ COMMAND(cmd_fetch)
 
   curl_easy_setopt(handle, CURLOPT_PRIVATE, req);
 
-  headers =
-    curl_slist_append(headers, "Accept-Charset: iso-8859-1, utf-8, us-ascii");
+  headers = curl_slist_append(headers, "Accept-Charset: iso-8859-1, utf-8, us-ascii");
   req->header_slist = headers;
   curl_easy_setopt(handle, CURLOPT_HTTPHEADER, headers);
 

--- a/src/function.c
+++ b/src/function.c
@@ -495,6 +495,7 @@ FUNTAB flist[] = {
   {"HASTYPE", fun_hastype, 2, 2, FN_REG | FN_STRIPANSI},
   {"HEIGHT", fun_height, 1, 2, FN_REG | FN_STRIPANSI},
   {"HIDDEN", fun_hidden, 1, 1, FN_REG | FN_STRIPANSI},
+  {"HTTP", fun_http, 3, 4, FN_REG | FN_STRIPANSI},
   {"HMAC", fun_hmac, 3, 4, FN_REG},
   {"HOME", fun_home, 1, 1, FN_REG | FN_STRIPANSI},
   {"HOST", fun_hostname, 1, 1, FN_REG | FN_STRIPANSI},

--- a/src/function.c
+++ b/src/function.c
@@ -495,7 +495,7 @@ FUNTAB flist[] = {
   {"HASTYPE", fun_hastype, 2, 2, FN_REG | FN_STRIPANSI},
   {"HEIGHT", fun_height, 1, 2, FN_REG | FN_STRIPANSI},
   {"HIDDEN", fun_hidden, 1, 1, FN_REG | FN_STRIPANSI},
-  {"HTTP", fun_http, 3, 4, FN_REG | FN_STRIPANSI},
+  {"HTTP", fun_http, 3, 4, FN_REG},
   {"HMAC", fun_hmac, 3, 4, FN_REG},
   {"HOME", fun_home, 1, 1, FN_REG | FN_STRIPANSI},
   {"HOST", fun_hostname, 1, 1, FN_REG | FN_STRIPANSI},


### PR DESCRIPTION
Offering this Feature Request for the following use case:

Making a function call where one is restricted to using a function. 
Example: Dynamic Exit evaluation. 