### PR TITLE
Fix unescaped backticks in CHANGES.188.md.

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -31,7 +31,7 @@ Minor changes
 Fixes
 -----
 * `udefault` only accepted 12 arguments, not the documented 32. [MG]
-* MOGRIFY`FORMAT was not being passed the mogrified channel name from MOGRIFY`CHANNAME as it should. Reported by Xperta [MT]
+* ``MOGRIFY`FORMAT`` was not being passed the mogrified channel name from ``MOGRIFY`CHANNAME`` as it should. Reported by Xperta [MT]
 
 Version 1.8.8 patchlevel 0 Apr 20 2020
 ======================================


### PR DESCRIPTION
@mike347 Just fyi - the `` were triggering code formatting unintentionally, which set me off on a journey of discovery to learn how to properly use code snippets that contain backticks... turns out the answer is ... yet more backticks 😛 