### PR TITLE
Issue 1336: Fix it so that mushtype.h #MAX_COMMAND_LEN can be raised.

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -32,6 +32,7 @@ Fixes
 -----
 * `udefault` only accepted 12 arguments, not the documented 32. [MG]
 * ``MOGRIFY`FORMAT`` was not being passed the mogrified channel name from ``MOGRIFY`CHANNAME`` as it should. Reported by Xperta [MT]
+* Fixed `MAX_COMMAND_LEN` alteration support, by improving the stability of the chunk system. Patch by Mercutio. [1336]
 
 Version 1.8.8 patchlevel 0 Apr 20 2020
 ======================================

--- a/hdrs/chunk.h
+++ b/hdrs/chunk.h
@@ -11,11 +11,11 @@
 typedef uintptr_t chunk_reference_t;
 #define NULL_CHUNK_REFERENCE 0
 
-chunk_reference_t chunk_create(char const *data, uint16_t len, uint8_t derefs);
+chunk_reference_t chunk_create(char const *data, uint32_t len, uint8_t derefs);
 void chunk_delete(chunk_reference_t reference);
-uint16_t chunk_fetch(chunk_reference_t reference, char *buffer,
-                     uint16_t buffer_len);
-uint16_t chunk_len(chunk_reference_t reference);
+uint32_t chunk_fetch(chunk_reference_t reference, char *buffer,
+                     uint32_t buffer_len);
+uint32_t chunk_len(chunk_reference_t reference);
 uint8_t chunk_derefs(chunk_reference_t reference);
 void chunk_migration(int count, chunk_reference_t **references);
 int chunk_num_swapped(void);

--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -241,7 +241,7 @@ struct bvm_asm {
 #include "bflags.c"
 
 static uint8_t *safe_get_bytecode(boolexp b) __attribute_malloc__;
-static uint8_t *get_bytecode(boolexp b, uint16_t *storelen);
+static uint8_t *get_bytecode(boolexp b, uint32_t *storelen);
 static struct boolexp_node *alloc_bool(void) __attribute_malloc__;
 static struct boolatr *alloc_atr(const char *name, const char *s,
                                  bool upcase_s) __attribute_malloc__;
@@ -302,7 +302,7 @@ static uint8_t *
 safe_get_bytecode(boolexp b)
 {
   uint8_t *bytecode;
-  uint16_t len;
+  uint32_t len;
 
   len = chunk_len(b);
   bytecode = mush_malloc(len, "boolexp.bytecode");
@@ -316,10 +316,10 @@ safe_get_bytecode(boolexp b)
  * \return a static copy of the bytecode.
  */
 static uint8_t *
-get_bytecode(boolexp b, uint16_t *storelen)
+get_bytecode(boolexp b, uint32_t *storelen)
 {
   static uint8_t bytecode[BUFFER_LEN * 2];
-  uint16_t len;
+  uint32_t len;
 
   len = chunk_fetch(b, (char *) bytecode, sizeof bytecode);
   if (storelen)
@@ -340,7 +340,7 @@ dup_bool(boolexp b)
 {
   boolexp r;
   uint8_t *bytecode;
-  uint16_t len = 0;
+  uint32_t len = 0;
 
   if (b == TRUE_BOOLEXP)
     return TRUE_BOOLEXP;
@@ -1840,7 +1840,7 @@ emit_bytecode(struct bvm_asm *a, int derefs)
   struct bvm_asmnode *i;
   struct bvm_strnode *s;
   char *pc, *bytecode;
-  uint16_t len, blen;
+  uint32_t len, blen;
 
   if (!a)
     return TRUE_BOOLEXP;
@@ -2240,7 +2240,7 @@ boolexp
 cleanup_boolexp(boolexp b)
 {
   uint8_t *pc, *bytecode;
-  uint16_t bytecode_len = 0;
+  uint32_t bytecode_len = 0;
   bvm_opcode op;
   int arg;
   bool revised = 0;

--- a/src/extmail.c
+++ b/src/extmail.c
@@ -1639,7 +1639,7 @@ real_send_mail(dbref player, dbref target, char *subject, char *message,
     size_t len = strlen(message) + 1;
     newp->msgid = chunk_create(message, len, 1);
   } else {
-    uint16_t len;
+    uint32_t len;
     char *text;
     char buff[BUFFER_LEN], newmsg[BUFFER_LEN], *nm = newmsg;
 

--- a/src/markup.c
+++ b/src/markup.c
@@ -1986,7 +1986,7 @@ parse_ansi_string(const char *source)
 
   /* The string has markup. Nuts. */
   as->flags |= AS_HAS_MARKUP;
-  as->markup = mush_calloc(BUFFER_LEN, sizeof(uint16_t), "ansi_string.markup");
+  as->markup = mush_calloc(BUFFER_LEN, sizeof(uint32_t), "ansi_string.markup");
 
   c = 0;
   for (s = as->source; *s;) {
@@ -2272,7 +2272,7 @@ flip_ansi_string(ansi_string *as)
   int s;
   int e;
   char tmp;
-  uint16_t mitmp;
+  uint32_t mitmp;
 
   for (s = 0, e = as->len - 1; s < e; s++, e--) {
     tmp = as->text[s];
@@ -2314,7 +2314,7 @@ ansi_string_delete(ansi_string *as, int start, int count)
   memmove(as->text + s, as->text + c, l);
   /* Move markup left. */
   if (as->markup) {
-    l *= sizeof(uint16_t);
+    l *= sizeof(uint32_t);
     memmove(as->markup + s, as->markup + c, l);
   }
   if (as->flags & AS_HAS_STANDALONE) {
@@ -2407,7 +2407,7 @@ ansi_string_replace(ansi_string *dst, int loc, int count, ansi_string *src)
       /* Special case: src has only standalone tags. */
       if (!dst->markup) {
         dst->markup =
-          mush_calloc(BUFFER_LEN, sizeof(uint16_t), "ansi_string.markup");
+          mush_calloc(BUFFER_LEN, sizeof(uint32_t), "ansi_string.markup");
         for (i = 0; i < dst->len; i++) {
           dst->markup[i] = NOMARKUP;
         }
@@ -2476,7 +2476,7 @@ ansi_string_replace(ansi_string *dst, int loc, int count, ansi_string *src)
   /* In case of copying from marked up string to non-marked-up. */
   if (!dst->markup) {
     dst->markup =
-      mush_calloc(BUFFER_LEN, sizeof(uint16_t), "ansi_string.markup");
+      mush_calloc(BUFFER_LEN, sizeof(uint32_t), "ansi_string.markup");
     for (i = 0; i < len; i++) {
       dst->markup[i] = NOMARKUP;
     }
@@ -2554,7 +2554,7 @@ ansi_string_replace(ansi_string *dst, int loc, int count, ansi_string *src)
     }
 
     /* Copy src's markup over, updating to new idx. */
-    memcpy(dst->markup + loc, src->markup, srclen * sizeof(uint16_t));
+    memcpy(dst->markup + loc, src->markup, srclen * sizeof(uint32_t));
     for (i = loc, j = 0; i < srcend; i++, j++) {
       if (src->markup[j] >= 0) {
         dst->markup[i] = src->markup[j] + idx;
@@ -2580,7 +2580,7 @@ scramble_ansi_string(ansi_string *as)
 {
   int i, j;
   char tmp;
-  uint16_t idxtmp;
+  uint32_t idxtmp;
 
   for (i = 0; i < as->len; i++) {
     j = get_random_u32(0, as->len - 1);


### PR DESCRIPTION
Previously, the `uint16_t` size used in `chunk.h` restricted the size of the chunk to as high as needed for increasing buffer lengths.
With the use of `uint32_t` size, it can now go up to a large enough number where `acc_chunk_init`'s ASSERT can catch it getting too high if `MAX_COMMAND_LEN` is set to `4096*4`. Before this, the game crashed before it could even reach that ASSERT.