### PR TITLE
#1430: Fix macOS compilation: include sys/random.h for getentropy, don't link info_slave/ssl_slave with libpq

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -37,6 +37,7 @@ Fixes
 * Telnet subnegotations displayed the subnegotation end character (SE) visibly for clients which had negotiated a unicode character set. Reported by Ben Gunderson. [1407, MG]
 * Fix for crashbug in @halt [1424,MT]
 * Repeating telnet characterset negotiation for a connection which had already negotiated as UTF-8 could cause a crash. From a report from Volund. [MG]
+* Fixed a `sys/random.h` compilation failure on MacOS, and fixed `info_slave`/`ssl_slave` PostgreSQL client library search paths. Reported by Adrian Irving-Beer. [1430, TK]
 
 Version 1.8.8 patchlevel 0 Apr 20 2020
 ======================================

--- a/Makefile.in
+++ b/Makefile.in
@@ -19,10 +19,11 @@ CC=@PTHREAD_CC@
 
 SQL_CFLAGS=@MYSQL_CFLAGS@ @POSTGRESQL_CPPFLAGS@
 SQL_LDFLAGS=@MYSQL_LDFLAGS@ @POSTGRESQL_LDFLAGS@
+SQL_LIBS=@POSTGRESQL_LIBS@
 
 CCFLAGS=@CFLAGS@ -I.. -I../hdrs -include ../config.h -include ../confmagic.h -include ../options.h @PTHREAD_CFLAGS@ @CPPFLAGS@ @ICU_CPPFLAGS@ @OPENSSL_INCLUDES@ @CURL_CFLAGS@
 LDFLAGS=@LDFLAGS@  @OPENSSL_LDFLAGS@
-CLIBS=@PTHREAD_LIBS@ @LIBS@ @ICU_LIBS@ @OPENSSL_LIBS@ @POSTGRESQL_LIBS@ @CURL_LIBS@
+CLIBS=@PTHREAD_LIBS@ @LIBS@ @ICU_LIBS@ @OPENSSL_LIBS@ @CURL_LIBS@
 INSTALL=@INSTALL@
 INSTALLDIR=$installdir
 CP=@CP@
@@ -46,7 +47,7 @@ all: config.h autogen game/mush.cnf
 	(cd src; @MAKE@ all "CC=$(CC)" "CCFLAGS=$(CCFLAGS)" \
 	"LDFLAGS=$(LDFLAGS)" "CLIBS=$(CLIBS)" "MAKE=$(MAKE)" \
 	"MAKEFLAGS=$(MAKEFLAGS)" "SQL_CFLAGS=$(SQL_CFLAGS)" \
-	"SQL_LDFLAGS=$(SQL_LDFLAGS)")
+	"SQL_LDFLAGS=$(SQL_LDFLAGS)" "SQL_LIBS=$(SQL_LIBS)")
 	@echo "If the make was successful, use 'make install' to install links."
 
 config.h: configure
@@ -90,7 +91,7 @@ install: localized all
 netmud:
 	(cd src; @MAKE@ netmud "CC=$(CC)" "CCFLAGS=$(CCFLAGS)" \
 	"SQL_CFLAGS=$(SQL_CFLAGS)" "SQL_LDFLAGS=$(SQL_LDFLAGS)" \
-	"LDFLAGS=$(LDFLAGS)" "CLIBS=$(CLIBS)" )
+	"SQL_LIBS=$(SQL_LIBS)" "LDFLAGS=$(LDFLAGS)" "CLIBS=$(CLIBS)" )
 
 access:
 	utils/make_access_cnf.sh game

--- a/config.h.in
+++ b/config.h.in
@@ -39,6 +39,8 @@
 
 #undef HAVE_POLL_H
 
+#undef HAVE_SYS_RANDOM_H
+
 #undef HAVE_SYS_SELECT_H
 
 #undef HAVE_SYS_INOTIFY_H

--- a/configure
+++ b/configure
@@ -7829,6 +7829,12 @@ then :
   printf "%s\n" "#define HAVE_SYS_SELECT_H 1" >>confdefs.h
 
 fi
+ac_fn_c_check_header_compile "$LINENO" "sys/random.h" "ac_cv_header_sys_random_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_random_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_SYS_RANDOM_H 1" >>confdefs.h
+
+fi
 ac_fn_c_check_header_compile "$LINENO" "sys/inotify.h" "ac_cv_header_sys_inotify_h" "$ac_includes_default"
 if test "x$ac_cv_header_sys_inotify_h" = xyes
 then :

--- a/configure.in
+++ b/configure.in
@@ -142,6 +142,7 @@ AC_CHECK_HEADERS([sys/stat.h sys/time.h sys/types.h sys/eventfd.h])
 AC_CHECK_HEADERS([sys/socket.h arpa/inet.h libintl.h netdb.h netinet/tcp.h])
 AC_CHECK_HEADERS([netinet/in.h sys/un.h sys/resource.h sys/event.h sys/uio.h])
 AC_CHECK_HEADERS([poll.h sys/select.h sys/inotify.h langinfo.h crypt.h])
+AC_CHECK_HEADERS([sys/random.h])
 AC_CHECK_HEADERS([event2/event.h event2/dns.h fenv.h sys/param.h syslog.h])
 AC_CHECK_HEADERS([sys/prctl.h byteswap.h endian.h sys/endian.h pthread.h])
 AC_CHECK_HEADERS([sys/ucred.h sys/file.h], [], [], [

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -62,7 +62,7 @@ all: $(OUTFILES)
 netmud: $(O_FILES)
 	@echo "Making netmud."
 	-mv -f netmud netmud~
-	$(CC) $(CCFLAGS) -o netmud $(O_FILES) $(LDFLAGS) $(SQL_LDFLAGS) $(LIBS)
+	$(CC) $(CCFLAGS) -o netmud $(O_FILES) $(LDFLAGS) $(SQL_LDFLAGS) $(LIBS) $(SQL_LIBS)
 
 # We recompile mysocket.c instead of reusing mysocket.o because we
 # want to do some error handing differently for info_slave.

--- a/src/myssl.c
+++ b/src/myssl.c
@@ -51,6 +51,11 @@ void shutdown_checkpoint(void);
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_SYS_RANDOM_H
+/* On macOS and some other systems, getentropy() is declared here
+   instead of in unistd.h */
+#include <sys/random.h>
+#endif
 #include <stdio.h>
 
 #include <openssl/bn.h>


### PR DESCRIPTION
Fixes #1430.