### PR TITLE
Upgrade all time handling to 64bit so Penn keeps working past 2038

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -20,6 +20,14 @@ Numbers next to the developer credit refer to Github issue numbers.
 Version 1.8.8 patchlevel 1 ??? ?? 202?
 ======================================
 
+Major Changes
+-------------
+
+* Times past 2038 (the 32-bit epoch limit) are now handled safely. Prompted by a patch from kaledin. [1428, TK]
+    * Object creation and modification times survive database saves past 2038, and objids with post-2038 creation times parse correctly.
+    * The connlog database now stores 64-bit timestamps, and is upgraded automatically.
+    NOTE: this upgrade is one-way. If you downgrade to an older version of PennMUSH afterwards, the older binary will disable connection logging; existing data is preserved, and logging will resume after re-upgrading.
+
 Minor changes
 -------------
 

--- a/hdrs/dbio.h
+++ b/hdrs/dbio.h
@@ -9,6 +9,7 @@
 
 #include <setjmp.h>
 #include <stdio.h>
+#include <time.h>
 #ifdef HAVE_LIBZ
 #include <zlib.h>
 #endif
@@ -46,9 +47,11 @@ int penn_feof(PENNFILE *);
 void putref(PENNFILE *f, long int ref);
 void putref_u32(PENNFILE *f, uint32_t ref);
 void putref_u64(PENNFILE *f, uint64_t ref);
+void putref_time(PENNFILE *f, time_t t);
 void putstring(PENNFILE *f, const char *s);
 void db_write_labeled_string(PENNFILE *f, char const *label, char const *value);
 void db_write_labeled_int(PENNFILE *f, char const *label, int value);
+void db_write_labeled_time(PENNFILE *f, char const *label, time_t value);
 void db_write_labeld_uint32(PENNFILE *, char const *, uint32_t);
 void db_write_labeled_dbref(PENNFILE *f, char const *label, dbref value);
 
@@ -60,6 +63,7 @@ char *getstring_noalloc(PENNFILE *f);
 long getref(PENNFILE *f);
 uint32_t getref_u32(PENNFILE *);
 uint64_t getref_u64(PENNFILE *f);
+time_t getref_time(PENNFILE *f);
 void db_read_this_labeled_string(PENNFILE *f, const char *label, char **val);
 void db_read_labeled_string(PENNFILE *f, char **label, char **val);
 void db_read_this_labeled_int(PENNFILE *f, const char *label, int *val);

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -5420,7 +5420,8 @@ report_mssp(DESC *d, char *buff, char **bp)
     /* Required by current spec, as of 2010-08-15 */
     queue_string_eol(d, "%s\t%s", "NAME", options.mud_name);
     queue_string_eol(d, "%s\t%d", "PLAYERS", count_players());
-    queue_string_eol(d, "%s\t%ld", "UPTIME", (long) globals.first_start_time);
+    queue_string_eol(d, "%s\t%s", "UPTIME",
+                     unparse_integer((intmax_t) globals.first_start_time));
     /* Not required, but we know anyway */
     queue_string_eol(d, "%s\t%d", "PORT", options.port);
     if (options.ssl_port) {
@@ -5438,8 +5439,8 @@ report_mssp(DESC *d, char *buff, char **bp)
                 options.mud_name);
     safe_format(buff, bp, "%c%s%c%d", MSSP_VAR, "PLAYERS", MSSP_VAL,
                 count_players());
-    safe_format(buff, bp, "%c%s%c%ld", MSSP_VAR, "UPTIME", MSSP_VAL,
-                (long) globals.first_start_time);
+    safe_format(buff, bp, "%c%s%c%s", MSSP_VAR, "UPTIME", MSSP_VAL,
+                unparse_integer((intmax_t) globals.first_start_time));
 
     safe_format(buff, bp, "%c%s%c%d", MSSP_VAR, "PORT", MSSP_VAL, options.port);
     if (options.ssl_port)
@@ -7405,14 +7406,14 @@ dump_reboot_db(void)
     putref(f, maxd);
     DESC_ITER (d) {
       putref(f, d->descriptor);
-      putref(f, d->connected_at);
+      putref_time(f, d->connected_at);
       putref(f, d->hide);
       putref(f, d->cmds);
       if (GoodObject(d->player))
         putref(f, d->player);
       else
         putref(f, -1);
-      putref(f, d->last_time);
+      putref_time(f, d->last_time);
       if (d->output_prefix)
         putstring(f, (char *) d->output_prefix);
       else
@@ -7438,7 +7439,7 @@ dump_reboot_db(void)
 
     putref(f, 0);
     putstring(f, poll_msg);
-    putref(f, globals.first_start_time);
+    putref_time(f, globals.first_start_time);
     putref(f, globals.reboot_count);
 #ifdef SSL_SLAVE
     putref(f, ssl_slave_pid);
@@ -7507,12 +7508,12 @@ load_reboot_db(void)
       d->http_request = NULL;
       d->closer = NOTHING;
       d->close_reason = "unknown";
-      d->connected_at = getref(f);
+      d->connected_at = getref_time(f);
       d->conn_timer = NULL;
       d->hide = getref(f);
       d->cmds = getref(f);
       d->player = getref(f);
-      d->last_time = getref(f);
+      d->last_time = getref_time(f);
       d->connected = (GoodObject(d->player) && IsPlayer(d->player))
                        ? CONN_PLAYER
                        : CONN_SCREEN;
@@ -7596,7 +7597,7 @@ load_reboot_db(void)
     } /* while loop */
 
     strcpy(poll_msg, getstring_noalloc(f));
-    globals.first_start_time = getref(f);
+    globals.first_start_time = getref_time(f);
     globals.reboot_count = getref(f) + 1;
 
 #ifndef SSL_SLAVE

--- a/src/connlog.c
+++ b/src/connlog.c
@@ -29,8 +29,45 @@
 #include "charconv.h"
 
 #define CONNLOG_APPID 0x42010FF2
-#define CONNLOG_VERSION 4
-#define CONNLOG_VERSIONS "4"
+#define CONNLOG_VERSION 5
+#define CONNLOG_VERSIONS "5"
+
+/* Placeholder disconnection time for connections that are still open.
+ * INT64_MAX, so that "disconn >= X" constraints match open connections
+ * for any real timestamp X. Versions before 5 used INT32_MAX. */
+#define CONNLOG_SENTINEL "9223372036854775807"
+
+/* Version 5 replaced the timestamps rtree_i32 virtual table, whose
+ * 32-bit coordinates can't hold dates past 2038, with a plain table,
+ * and widened the still-connected sentinel from INT32_MAX to
+ * INT64_MAX. Used by every upgrade path; must run while no view or
+ * trigger references timestamps. */
+#define CONNLOG_TS_TO_TABLE_SQL                                                \
+  "CREATE TABLE timestamps2(id INTEGER NOT NULL PRIMARY KEY, conn "            \
+  "INTEGER NOT NULL, disconn INTEGER NOT NULL);"                               \
+  "INSERT INTO timestamps2(id, conn, disconn) SELECT id, conn, "               \
+  "disconn FROM timestamps;"                                                   \
+  "DROP TABLE timestamps;"                                                     \
+  "ALTER TABLE timestamps2 RENAME TO timestamps;"                              \
+  "CREATE INDEX ts_conn_idx ON timestamps(conn);"                              \
+  "CREATE INDEX ts_disconn_idx ON timestamps(disconn);"                        \
+  "UPDATE timestamps SET disconn = " CONNLOG_SENTINEL                          \
+  " WHERE disconn = 2147483647;"
+
+/* The connlog view and its trigger, shared by the creation and every
+ * upgrade path. */
+#define CONNLOG_VIEW_SQL                                                       \
+  "CREATE VIEW connlog(id, dbref, name, ipaddr, hostname, conn, "              \
+  "disconn, reason, ssl, websocket) AS SELECT c.id, c.dbref, c.name, "         \
+  "a.ipaddr, a.hostname, ts.conn, ts.disconn, c.reason, c.ssl, "               \
+  "c.websocket FROM connections AS c "                                         \
+  "JOIN timestamps AS ts ON c.id = ts.id JOIN addrs AS a ON c.addrid = "       \
+  "a.id;"                                                                      \
+  "CREATE TRIGGER conn_logout INSTEAD OF UPDATE OF disconn,reason ON "         \
+  "connlog BEGIN UPDATE connections SET reason = NEW.reason WHERE id = "       \
+  "NEW.id; UPDATE timestamps SET disconn = NEW.disconn WHERE id = "            \
+  "NEW.id; "                                                                   \
+  "END;"
 
 sqlite3 *connlog_db;
 
@@ -123,9 +160,6 @@ init_conndb(bool rebooting)
   }
 
   if (app_id == 0) {
-    /* Sqlite 3.24 added the ability to have auxilary columns in RTree
-       virtual tables. Consider folding the connections table into it
-       to avoid a join? */
     do_rawlog(LT_ERR, "Building connlog database.");
     if (sqlite3_exec(
           connlog_db,
@@ -136,7 +170,10 @@ init_conndb(bool rebooting)
           "DROP TABLE IF EXISTS timestamps;"
           "DROP TABLE IF EXISTS checkpoint;"
           "DROP TABLE IF EXISTS addrs;"
-          "CREATE VIRTUAL TABLE timestamps USING rtree_i32(id, conn, disconn);"
+          "CREATE TABLE timestamps(id INTEGER NOT NULL PRIMARY KEY, conn "
+          "INTEGER NOT NULL, disconn INTEGER NOT NULL);"
+          "CREATE INDEX ts_conn_idx ON timestamps(conn);"
+          "CREATE INDEX ts_disconn_idx ON timestamps(disconn);"
           "CREATE TABLE addrs(id INTEGER NOT NULL PRIMARY KEY, ipaddr TEXT NOT "
           "NULL UNIQUE, hostname TEXT NOT NULL);"
           "CREATE TABLE connections(id INTEGER NOT NULL PRIMARY KEY, dbref "
@@ -148,18 +185,7 @@ init_conndb(bool rebooting)
           "CREATE TABLE checkpoint(id INTEGER NOT NULL PRIMARY KEY, timestamp "
           "INTEGER NOT NULL);"
           "INSERT INTO checkpoint VALUES (1, strftime('%s', 'now'));"
-          "CREATE VIEW connlog(id, dbref, name, ipaddr, hostname, conn, "
-          "disconn, reason, ssl, websocket) AS SELECT c.id, c.dbref, c.name, "
-          "a.ipaddr, a.hostname, ts.conn, ts.disconn, c.reason, c.ssl, "
-          "c.websocket FROM "
-          "connections AS c "
-          "JOIN timestamps AS ts ON c.id = ts.id JOIN addrs AS a ON c.addrid = "
-          "a.id;"
-          "CREATE TRIGGER conn_logout INSTEAD OF UPDATE OF disconn,reason ON "
-          "connlog BEGIN UPDATE connections SET reason = NEW.reason WHERE id = "
-          "NEW.id; UPDATE timestamps SET disconn = NEW.disconn WHERE id = "
-          "NEW.id; "
-          "END;",
+          CONNLOG_VIEW_SQL,
           NULL, NULL, &err) != SQLITE_OK) {
       do_rawlog(LT_ERR, "Unable to build connlog database: %s", err);
       sqlite3_free(err);
@@ -186,18 +212,8 @@ init_conndb(bool rebooting)
           "dbref, name, reason, (SELECT id FROM addrs WHERE addrs.ipaddr = "
           "backup.ipaddr) FROM backup;"
           "DROP TABLE backup;"
-          "CREATE VIEW connlog(id, dbref, name, ipaddr, hostname, conn, "
-          "disconn, reason, ssl, websocket) AS SELECT c.id, c.dbref, c.name, "
-          "a.ipaddr, "
-          "a.hostname, ts.conn, ts.disconn, c.reason, c.ssl, c.websocket FROM "
-          "connections AS c "
-          "JOIN timestamps AS ts ON c.id = ts.id JOIN addrs AS a ON c.addrid = "
-          "a.id;"
-          "CREATE TRIGGER conn_logout INSTEAD OF UPDATE OF disconn,reason ON "
-          "connlog BEGIN UPDATE connections SET reason = NEW.reason WHERE id = "
-          "NEW.id; UPDATE timestamps SET disconn = NEW.disconn WHERE id = "
-          "NEW.id; "
-          "END;"
+          CONNLOG_TS_TO_TABLE_SQL
+          CONNLOG_VIEW_SQL
           "PRAGMA user_version = " CONNLOG_VERSIONS ";"
           "COMMIT TRANSACTION",
           NULL, NULL, &err) != SQLITE_OK) {
@@ -213,18 +229,8 @@ init_conndb(bool rebooting)
           "BEGIN TRANSACTION;"
           "ALTER TABLE connections ADD COLUMN ssl INTEGER;"
           "ALTER TABLE connections ADD COLUMN websocket INTEGER;"
-          "CREATE VIEW connlog(id, dbref, name, ipaddr, hostname, conn, "
-          "disconn, "
-          "reason, ssl, websocket) AS SELECT c.id, c.dbref, c.name, a.ipaddr, "
-          "a.hostname, ts.conn, "
-          "ts.disconn, c.reason, c.ssl, c.websocket FROM connections AS c JOIN "
-          "timestamps AS ts ON "
-          "c.id = ts.id JOIN addrs AS a ON c.addrid = a.id;"
-          "CREATE TRIGGER conn_logout INSTEAD OF UPDATE OF disconn,reason ON "
-          "connlog BEGIN UPDATE connections SET reason = NEW.reason WHERE id = "
-          "NEW.id; UPDATE timestamps SET disconn = NEW.disconn WHERE id = "
-          "NEW.id; "
-          "END;"
+          CONNLOG_TS_TO_TABLE_SQL
+          CONNLOG_VIEW_SQL
           "PRAGMA user_version = " CONNLOG_VERSIONS ";"
           "COMMIT TRANSACTION",
           NULL, NULL, &err) != SQLITE_OK) {
@@ -241,18 +247,24 @@ init_conndb(bool rebooting)
           "ALTER TABLE connections ADD COLUMN ssl INTEGER;"
           "ALTER TABLE connections ADD COLUMN websocket INTEGER;"
           "DROP VIEW connlog;"
-          "CREATE VIEW connlog(id, dbref, name, ipaddr, hostname, conn, "
-          "disconn, reason, ssl, websocket) AS SELECT c.id, c.dbref, c.name, "
-          "a.ipaddr, "
-          "a.hostname, ts.conn, ts.disconn, c.reason, c.ssl, c.websocket FROM "
-          "connections AS c "
-          "JOIN timestamps AS ts ON c.id = ts.id JOIN addrs AS a ON c.addrid = "
-          "a.id;"
-          "CREATE TRIGGER conn_logout INSTEAD OF UPDATE OF disconn,reason ON "
-          "connlog BEGIN UPDATE connections SET reason = NEW.reason WHERE id = "
-          "NEW.id; UPDATE timestamps SET disconn = NEW.disconn WHERE id = "
-          "NEW.id; "
-          "END;"
+          CONNLOG_TS_TO_TABLE_SQL
+          CONNLOG_VIEW_SQL
+          "PRAGMA user_version = " CONNLOG_VERSIONS ";"
+          "COMMIT TRANSACTION",
+          NULL, NULL, &err) != SQLITE_OK) {
+      do_rawlog(LT_ERR, "Upgrade failed: %s", err);
+      sqlite3_free(err);
+      sqlite3_exec(connlog_db, "ROLLBACK TRANSACTION", NULL, NULL, NULL);
+      goto error_cleanup;
+    }
+  } else if (version == 4) {
+    do_rawlog(LT_ERR, "Upgrading connlog db from 4 to %d", CONNLOG_VERSION);
+    if (sqlite3_exec(
+          connlog_db,
+          "BEGIN TRANSACTION;"
+          "DROP VIEW connlog;"
+          CONNLOG_TS_TO_TABLE_SQL
+          CONNLOG_VIEW_SQL
           "PRAGMA user_version = " CONNLOG_VERSIONS ";"
           "COMMIT TRANSACTION",
           NULL, NULL, &err) != SQLITE_OK) {
@@ -282,7 +294,7 @@ init_conndb(bool rebooting)
           "checkpoint WHERE id = 1);"
           "UPDATE connlog SET reason = 'unexpected shutdown', "
           "disconn = (SELECT timestamp FROM checkpoint "
-          "WHERE id = 1) WHERE disconn = 2147483647;"
+          "WHERE id = 1) WHERE disconn = " CONNLOG_SENTINEL ";"
           "COMMIT TRANSACTION",
           NULL, NULL, &err) != SQLITE_OK) {
       do_rawlog(LT_ERR, "Unable to update past logins: %s", err);
@@ -324,7 +336,7 @@ shutdown_conndb(bool rebooting)
                      "BEGIN TRANSACTION;"
                      "UPDATE connlog SET reason = 'shutdown', disconn = "
                      "strftime('%s', 'now') "
-                     "WHERE disconn = 2147483647;"
+                     "WHERE disconn = " CONNLOG_SENTINEL ";"
                      "COMMIT TRANSACTION",
                      NULL, NULL, &err) != SQLITE_OK) {
       do_rawlog(LT_ERR, "Unable to update connlog database: %s", err);
@@ -359,7 +371,7 @@ connlog_connection(const char *ip, const char *host, bool ssl)
   }
   adder = prepare_statement(connlog_db,
                             "INSERT INTO timestamps(conn, disconn) VALUES "
-                            "(strftime('%s', 'now'), 2147483647)",
+                            "(strftime('%s', 'now'), " CONNLOG_SENTINEL ")",
                             "connlog.connection.time");
   do {
     status = sqlite3_step(adder);
@@ -563,7 +575,7 @@ FUNCTION(fun_connlog)
       idx += 1;
       continue;
     } else if (sqlite3_stricmp(args[idx], "between") == 0) {
-      int starttime, endtime;
+      sqlite3_int64 starttime, endtime;
 
       if (time_constraint) {
         safe_str("#-1 TOO MANY CONSTRAINTS", buff, bp);
@@ -571,14 +583,14 @@ FUNCTION(fun_connlog)
       } else if (nargs <= idx + 2) {
         safe_str("#-1 BETWEEN MISSING RANGE", buff, bp);
         goto error_cleanup;
-      } else if (!is_strict_integer(args[idx + 1]) ||
-                 !is_strict_integer(args[idx + 2])) {
+      } else if (!is_strict_int64(args[idx + 1]) ||
+                 !is_strict_int64(args[idx + 2])) {
         safe_str(T(e_ints), buff, bp);
         goto error_cleanup;
       }
 
-      starttime = parse_integer(args[idx + 1]);
-      endtime = parse_integer(args[idx + 2]);
+      starttime = parse_int64(args[idx + 1], NULL, 10);
+      endtime = parse_int64(args[idx + 2], NULL, 10);
 
       if (endtime < starttime || starttime > mudtime) {
         if (count_only) {
@@ -592,12 +604,12 @@ FUNCTION(fun_connlog)
       } else {
         sqlite3_str_appendall(query, " AND");
       }
-      sqlite3_str_appendf(query, " (conn <= %d AND disconn >= %d)", endtime,
+      sqlite3_str_appendf(query, " (conn <= %lld AND disconn >= %lld)", endtime,
                           starttime);
       time_constraint = 1;
       idx += 3;
     } else if (sqlite3_stricmp(args[idx], "at") == 0) {
-      int when;
+      sqlite3_int64 when;
 
       if (time_constraint) {
         safe_str("#-1 TOO MANY CONSTRAINTS", buff, bp);
@@ -605,11 +617,11 @@ FUNCTION(fun_connlog)
       } else if (nargs <= idx + 1) {
         safe_str("#-1 AT MISSING TIME", buff, bp);
         goto error_cleanup;
-      } else if (!is_strict_integer(args[idx + 1])) {
+      } else if (!is_strict_int64(args[idx + 1])) {
         safe_str(T(e_int), buff, bp);
         goto error_cleanup;
       }
-      when = parse_integer(args[idx + 1]);
+      when = parse_int64(args[idx + 1], NULL, 10);
       if (when > mudtime) {
         if (count_only) {
           safe_chr('0', buff, bp);
@@ -621,43 +633,44 @@ FUNCTION(fun_connlog)
       } else {
         sqlite3_str_appendall(query, " AND");
       }
-      sqlite3_str_appendf(query, " (conn <= %d AND disconn >= %d)", when, when);
+      sqlite3_str_appendf(query, " (conn <= %lld AND disconn >= %lld)", when,
+                          when);
       time_constraint = 1;
       idx += 2;
     } else if (sqlite3_stricmp(args[idx], "before") == 0) {
-      int when;
+      sqlite3_int64 when;
       if (time_constraint) {
         safe_str("#-1 TOO MANY CONSTRAINTS", buff, bp);
         goto error_cleanup;
       } else if (nargs <= idx + 1) {
         safe_str("#-1 BEFORE MISSING TIME", buff, bp);
         goto error_cleanup;
-      } else if (!is_strict_integer(args[idx + 1])) {
+      } else if (!is_strict_int64(args[idx + 1])) {
         safe_str(T(e_int), buff, bp);
         goto error_cleanup;
       }
-      when = parse_integer(args[idx + 1]);
+      when = parse_int64(args[idx + 1], NULL, 10);
       if (first_constraint) {
         first_constraint = 0;
       } else {
         sqlite3_str_appendall(query, " AND");
       }
-      sqlite3_str_appendf(query, " conn < %d", when);
+      sqlite3_str_appendf(query, " conn < %lld", when);
       time_constraint = 1;
       idx += 2;
     } else if (sqlite3_stricmp(args[idx], "after") == 0) {
-      int when;
+      sqlite3_int64 when;
       if (time_constraint) {
         safe_str("#-1 TOO MANY CONSTRAINTS", buff, bp);
         goto error_cleanup;
       } else if (nargs <= idx + 1) {
         safe_str("#-1 AFTER MISSING TIME", buff, bp);
         goto error_cleanup;
-      } else if (!is_strict_integer(args[idx + 1])) {
+      } else if (!is_strict_int64(args[idx + 1])) {
         safe_str(T(e_int), buff, bp);
         goto error_cleanup;
       }
-      when = parse_integer(args[idx + 1]);
+      when = parse_int64(args[idx + 1], NULL, 10);
       if (when >= mudtime) {
         if (count_only) {
           safe_chr('0', buff, bp);
@@ -670,7 +683,8 @@ FUNCTION(fun_connlog)
         sqlite3_str_appendall(query, " AND");
       }
       sqlite3_str_appendf(query,
-                          " (conn > %d OR (conn <= %d AND disconn >= %d))",
+                          " (conn > %lld OR (conn <= %lld AND disconn >= "
+                          "%lld))",
                           when, when, when);
       time_constraint = 1;
       idx += 2;
@@ -829,7 +843,7 @@ FUNCTION(fun_connrecord)
     status = sqlite3_step(rec);
   } while (is_busy_status(status));
   if (status == SQLITE_ROW) {
-    int32_t disco;
+    int64_t disco;
     safe_dbref(sqlite3_column_int(rec, 0), buff, bp);
     safe_str(sep, buff, bp);
     safe_str((const char *) sqlite3_column_text(rec, 1), buff, bp);
@@ -838,10 +852,10 @@ FUNCTION(fun_connrecord)
     safe_str(sep, buff, bp);
     safe_str((const char *) sqlite3_column_text(rec, 3), buff, bp);
     safe_str(sep, buff, bp);
-    safe_integer(sqlite3_column_int(rec, 4), buff, bp);
-    disco = sqlite3_column_int(rec, 5);
+    safe_integer(sqlite3_column_int64(rec, 4), buff, bp);
+    disco = sqlite3_column_int64(rec, 5);
     safe_str(sep, buff, bp);
-    if (disco == INT32_MAX) {
+    if (disco == INT64_MAX) {
       safe_str("-1", buff, bp);
     } else {
       safe_integer(disco, buff, bp);

--- a/src/cque.c
+++ b/src/cque.c
@@ -65,7 +65,7 @@ static int add_to_sem(dbref player, int am, const char *name);
 static int queue_limit(dbref player);
 void free_qentry(MQUE *point);
 static int pay_queue(dbref player, const char *command);
-void wait_que(dbref executor, int waittill, char *command, dbref enactor,
+void wait_que(dbref executor, time_t waittill, char *command, dbref enactor,
               dbref sem, const char *semattr, int until, MQUE *parent_queue);
 int que_next(void);
 
@@ -870,6 +870,24 @@ queue_attribute_useatr(dbref executor, ATTR *a, dbref enactor, PE_REGS *pe_regs,
   return 1;
 }
 
+/** Add a relative wait to a base time, saturating instead of
+ * overflowing time_t when the offset is absurdly large in either
+ * direction. Deadlines never go below 0.
+ */
+static time_t
+wait_deadline(time_t base, time_t offset)
+{
+  time_t max =
+    (sizeof(time_t) == 8) ? (time_t) INT64_MAX : (time_t) INT32_MAX;
+  if (offset > 0) {
+    if (base > max - offset)
+      return max;
+  } else if (offset < -base) {
+    return 0;
+  }
+  return base + offset;
+}
+
 /** Queue an entry on the wait or semaphore queues.
  * This function creates and adds a queue entry to the wait queue
  * or the semaphore queue. Wait queue entries are sorted by when
@@ -885,8 +903,8 @@ queue_attribute_useatr(dbref executor, ATTR *a, dbref enactor, PE_REGS *pe_regs,
  * \param parent_queue the queue entry the \@wait command was executed in
  */
 void
-wait_que(dbref executor, int waittill, char *command, dbref enactor, dbref sem,
-         const char *semattr, int until, MQUE *parent_queue)
+wait_que(dbref executor, time_t waittill, char *command, dbref enactor,
+         dbref sem, const char *semattr, int until, MQUE *parent_queue)
 {
   MQUE *tmp;
   NEW_PE_INFO *pe_info;
@@ -921,10 +939,10 @@ wait_que(dbref executor, int waittill, char *command, dbref enactor, dbref sem,
   tmp->queue_type |= queue_type;
 
   if (until) {
-    tmp->wait_until = (time_t) waittill;
+    tmp->wait_until = waittill;
   } else {
     if (waittill >= 0)
-      tmp->wait_until = mudtime + waittill;
+      tmp->wait_until = wait_deadline(mudtime, waittill);
     else
       tmp->wait_until = 0; /* semaphore wait without a timeout */
   }
@@ -1560,13 +1578,14 @@ do_wait(dbref executor, dbref enactor, char *arg1, const char *cmd, bool until,
 {
   dbref thing;
   char *tcount = NULL, *aname = NULL;
-  int waitfor, num;
+  time_t waitfor;
+  int num;
   ATTR *a;
 
-  if (is_strict_integer(arg1)) {
+  if (is_strict_int64(arg1)) {
     /* normal wait */
-    wait_que(executor, parse_integer(arg1), (char *) cmd, enactor, NOTHING,
-             NULL, until, parent_queue);
+    wait_que(executor, (time_t) parse_int64(arg1, NULL, 10), (char *) cmd,
+             enactor, NOTHING, NULL, until, parent_queue);
     return;
   }
   /* semaphore wait with optional timeout */
@@ -1588,7 +1607,7 @@ do_wait(dbref executor, dbref enactor, char *arg1, const char *cmd, bool until,
   if (aname) {
     tcount = strchr(aname, '/');
     if (!tcount) {
-      if (is_strict_integer(aname)) { /* Timeout */
+      if (is_strict_int64(aname)) { /* Timeout */
         tcount = aname;
         aname = (char *) "SEMAPHORE";
       } else { /* Attribute */
@@ -1609,7 +1628,7 @@ do_wait(dbref executor, dbref enactor, char *arg1, const char *cmd, bool until,
   }
   /* get timeout, default of -1 */
   if (tcount && *tcount)
-    waitfor = parse_integer(tcount);
+    waitfor = (time_t) parse_int64(tcount, NULL, 10);
   else
     waitfor = -1;
   add_to_sem(thing, 1, aname);
@@ -1664,34 +1683,31 @@ do_waitpid(dbref player, const char *pidstr, const char *timestr, bool until)
     return;
   }
 
-  if (!is_strict_integer(timestr)) {
+  if (!is_strict_int64(timestr)) {
     notify(player, T("That is not a valid timestamp."));
     return;
   }
 
   if (until) {
-    int when;
+    time_t when;
 
-    when = parse_integer(timestr);
+    when = (time_t) parse_int64(timestr, NULL, 10);
 
     if (when < 0)
       when = 0;
 
-    q->wait_until = (time_t) when;
+    q->wait_until = when;
 
   } else {
-    int offset = parse_integer(timestr);
+    time_t offset = (time_t) parse_int64(timestr, NULL, 10);
 
     /* If timestr looks like +NNN or -NNN, add or subtract a number
        of seconds to the current timeout. Otherwise, change timeout.
      */
     if (timestr[0] == '+' || timestr[0] == '-')
-      q->wait_until += offset;
+      q->wait_until = wait_deadline(q->wait_until, offset);
     else
-      q->wait_until = mudtime + offset;
-
-    if (q->wait_until < 0)
-      q->wait_until = 0;
+      q->wait_until = wait_deadline(mudtime, offset);
   }
 
   /* Now adjust it in the wait queue. Not a clever approach, but I

--- a/src/db.c
+++ b/src/db.c
@@ -278,6 +278,22 @@ putref_u64(PENNFILE *f, uint64_t ref)
 #endif
 }
 
+/** Output a time_t to a file.
+ * Kept 64-bit even on platforms with a 32-bit long so that dates past
+ * 2038 survive serialization.
+ * \param f file pointer to write to.
+ * \param t value to write.
+ */
+void
+putref_time(PENNFILE *f, time_t t)
+{
+#ifdef WIN32
+  penn_fprintf(f, "%I64d\n", (int64_t) t);
+#else
+  penn_fprintf(f, "%" PRId64 "\n", (int64_t) t);
+#endif
+}
+
 /** Output a string to a file.
  * This function writes a string to a file, double-quoted,
  * appropriately escaping quotes and backslashes (the escape character).
@@ -597,6 +613,16 @@ db_write_labeled_int(PENNFILE *f, char const *label, int value)
 }
 
 void
+db_write_labeled_time(PENNFILE *f, char const *label, time_t value)
+{
+#ifdef WIN32
+  penn_fprintf(f, "%s %I64d\n", label, (int64_t) value);
+#else
+  penn_fprintf(f, "%s %" PRId64 "\n", label, (int64_t) value);
+#endif
+}
+
+void
 db_write_labeled_dbref(PENNFILE *f, char const *label, dbref value)
 {
   penn_fprintf(f, "%s #%d\n", label, value);
@@ -660,8 +686,8 @@ db_write_obj_basic(PENNFILE *f, dbref i, struct object *o)
   db_write_labeled_string(f, "powers",
                           bits_to_string("POWER", o->powers, GOD, NOTHING));
   db_write_labeled_string(f, "warnings", unparse_warnings(o->warnings));
-  db_write_labeled_int(f, "created", (int) o->creation_time);
-  db_write_labeled_int(f, "modified", (int) o->modification_time);
+  db_write_labeled_time(f, "created", o->creation_time);
+  db_write_labeled_time(f, "modified", o->modification_time);
 }
 
 /** Write out an object.
@@ -1016,7 +1042,7 @@ getref(PENNFILE *f)
     longjmp(db_err, 1);
   }
   dbline++;
-  return parse_integer(buf);
+  return (long) parse_int64(buf, NULL, 10);
 }
 
 /** Read in a uint32_t
@@ -1049,6 +1075,24 @@ getref_u64(PENNFILE *f)
   }
   dbline++;
   return parse_uint64(buf, NULL, 10);
+}
+
+/** Read in a time_t.
+ * Kept 64-bit even on platforms with a 32-bit long so that dates past
+ * 2038 survive serialization.
+ * \param f file pointer to read from.
+ * \return time_t read.
+ */
+time_t
+getref_time(PENNFILE *f)
+{
+  static char buf[BUFFER_LEN];
+  if (!penn_fgets(buf, sizeof(buf), f)) {
+    do_rawlog(LT_ERR, "Unexpected EOF at line %d", dbline);
+    longjmp(db_err, 1);
+  }
+  dbline++;
+  return (time_t) parse_int64(buf, NULL, 10);
 }
 
 /** Read in a string, into a static buffer.
@@ -1836,10 +1880,10 @@ db_read(PENNFILE *f)
             o->warnings = parse_warnings(NOTHING, value);
             break;
           case LBL_CREATED:
-            o->creation_time = (time_t) parse_integer(value);
+            o->creation_time = (time_t) parse_int64(value, NULL, 10);
             break;
           case LBL_MODIFIED:
-            o->modification_time = (time_t) parse_integer(value);
+            o->modification_time = (time_t) parse_int64(value, NULL, 10);
             break;
           case LBL_ATTRS: {
             int attrcount = parse_integer(value);

--- a/src/extmail.c
+++ b/src/extmail.c
@@ -2423,7 +2423,7 @@ dump_mail(PENNFILE *fp)
   for (mp = HEAD; mp != NULL; mp = mp->next) {
     putref(fp, mp->to);
     putref(fp, mp->from);
-    putref(fp, mp->from_ctime);
+    putref_time(fp, mp->from_ctime);
     putstring(fp, show_time(mp->time, 0));
     if (mp->subject)
       putstring(fp, uncompress(mp->subject));
@@ -2575,7 +2575,7 @@ load_mail(PENNFILE *fp)
   mp->to = getref(fp);
   mp->from = getref(fp);
   if (mail_flags & MDBF_SENDERCTIME)
-    mp->from_ctime = (time_t) getref(fp);
+    mp->from_ctime = getref_time(fp);
   else
     mp->from_ctime = 0; /* No one will have this creation time */
 
@@ -2610,7 +2610,7 @@ load_mail(PENNFILE *fp)
     mp->to = getref(fp);
     mp->from = getref(fp);
     if (mail_flags & MDBF_SENDERCTIME)
-      mp->from_ctime = (time_t) getref(fp);
+      mp->from_ctime = getref_time(fp);
     else
       mp->from_ctime = 0; /* No one will have this creation time */
     if (do_convtime(getstring_noalloc(fp), &ttm))

--- a/src/funtime.c
+++ b/src/funtime.c
@@ -48,11 +48,11 @@ FUNCTION(fun_timefmt)
 
   if (nargs >= 2 && args[1] && *args[1]) {
 
-    if (!is_integer(args[1])) {
+    if (!is_strict_int64(args[1])) {
       safe_str(T(e_int), buff, bp);
       return;
     }
-    tt = parse_integer(args[1]);
+    tt = (time_t) parse_int64(args[1], NULL, 10);
     if (errno == ERANGE) {
       safe_str(T(e_range), buff, bp);
       return;
@@ -171,11 +171,11 @@ FUNCTION(fun_convsecs)
   struct tm *ttm;
   bool utc = 0;
 
-  if (!is_integer(args[0])) {
+  if (!is_strict_int64(args[0])) {
     safe_str(T(e_int), buff, bp);
     return;
   }
-  tt = parse_integer(args[0]);
+  tt = (time_t) parse_int64(args[0], NULL, 10);
   if (errno == ERANGE) {
     safe_str(T(e_range), buff, bp);
     return;
@@ -696,11 +696,11 @@ FUNCTION(fun_isdaylight)
   time_t when = mudtime;
 
   if (nargs >= 1 && args[0] && *args[0]) {
-    if (!is_integer(args[0])) {
+    if (!is_strict_int64(args[0])) {
       safe_str(T(e_int), buff, bp);
       return;
     }
-    when = parse_integer(args[0]);
+    when = (time_t) parse_int64(args[0], NULL, 10);
     if (errno == ERANGE) {
       safe_str(T(e_range), buff, bp);
       return;

--- a/src/parse.c
+++ b/src/parse.c
@@ -199,9 +199,9 @@ real_parse_objid(char const *str, bool strict)
     if (GoodObject(it)) {
       time_t matchtime;
       p++;
-      if (!is_strict_integer(p))
+      if (!is_strict_int64(p))
         return NOTHING;
-      matchtime = parse_integer(p);
+      matchtime = (time_t) parse_int64(p, NULL, 10);
       return (CreTime(it) == matchtime) ? it : NOTHING;
     } else
       return NOTHING;
@@ -210,6 +210,19 @@ real_parse_objid(char const *str, bool strict)
   } else {
     return parse_dbref(str);
   }
+}
+
+TEST_GROUP(parse_objid)
+{
+  /* Objids must round-trip creation times past 2038 (the 32-bit epoch
+     limit). Runs with the game db loaded, so borrow God for a moment. */
+  time_t saved = CreTime(GOD);
+  CreTime(GOD) = 4102444800; /* Jan 1 2100 */
+  TEST("parse_objid.1", parse_objid("#1:4102444800") == GOD);
+  TEST("parse_objid.2", real_parse_objid("#1:4102444800", 1) == GOD);
+  TEST("parse_objid.3", parse_objid("#1:4102444801") == NOTHING);
+  CreTime(GOD) = saved;
+  TEST("parse_objid.4", parse_objid("#1:notanumber") == NOTHING);
 }
 
 /** Given a string, parse out a boolean value.

--- a/src/tests.inc
+++ b/src/tests.inc
@@ -30,6 +30,7 @@ void test_trim_space_sep(int *, int *);
 void test_utf8_to_latin1(int *, int *);
 void test_utf8_to_latin1_us(int *, int *);
 void test_valid_utf8(int *, int *);
+void test_parse_objid(int *, int *);
 struct test_record {
     const char *name;
     void (*fun)(int *, int *);
@@ -73,5 +74,6 @@ static struct test_record tests[] = {
 {"utf8_to_latin1", test_utf8_to_latin1, "||", TEST_NOT_RUN},
 {"utf8_to_latin1_us", test_utf8_to_latin1_us, "||", TEST_NOT_RUN},
 {"valid_utf8", test_valid_utf8, "||", TEST_NOT_RUN},
+{"parse_objid", test_parse_objid, "||", TEST_NOT_RUN},
 {NULL, NULL, NULL, TEST_NOT_RUN}
 };

--- a/test/testtime64.t
+++ b/test/testtime64.t
@@ -1,0 +1,30 @@
+login mortal
+run tests:
+# Y2038: time functions must accept epoch values past 2^31-1 (Jan 19 2038).
+# 4102444800 is Fri Jan  1 00:00:00 2100 UTC.
+test('time64.convsecs.1', $mortal, 'think convutcsecs(4102444800)', '^Fri Jan 01 00:00:00 2100$');
+test('time64.convsecs.2', $mortal, 'think convsecs(2147483648, utc)', '^Tue Jan 19 03:14:08 2038$');
+test('time64.convsecs.3', $mortal, 'think convsecs(psychic-friends-network)', 'ARGUMENT MUST BE INTEGER');
+# convtime already returned 64-bit values; the round trip must work both ways.
+test('time64.roundtrip.1', $mortal, 'think convutctime(convutcsecs(4102444800))', '^4102444800$');
+test('time64.timefmt.1', $mortal, 'think timefmt($Y-$m-$d $H:$M:$S, 4102444800, utc)', '^2100-01-01 00:00:00$');
+# isdaylight with a post-2038 epoch should answer, not reject the argument.
+test('time64.isdaylight.1', $mortal, 'think isdaylight(4102444800)', '^[01]$');
+# objid parsing must accept 64-bit creation timestamps.
+test('time64.objid.1', $mortal, 'think num(#1:[csecs(#1)])', '^#1$');
+test('time64.objid.2', $mortal, 'think num(#1:4102444800)', '#-1$');
+# @wait/until with a post-2038 absolute time: over 2 billion seconds remain.
+# Halted pids linger in lpids() until the next queue cycle, so always
+# check the newest entry via last().
+$mortal->command('@wait/until 4102444800=think this should not run for decades');
+test('time64.waituntil.1', $mortal, 'think gt(pidinfo(last(lpids()), time), 2000000000)', '^1$');
+$mortal->command('@halt/pid [last(lpids())]');
+# Semaphore form: @wait/until <object>/<64-bit time>=command
+$mortal->command('@wait/until me/4102444800=think this should not run for decades');
+test('time64.semwait.1', $mortal, 'think gt(pidinfo(last(lpids()), time), 2000000000)', '^1$');
+$mortal->command('@drain me');
+# A huge relative wait must saturate, not overflow into the past and
+# run immediately.
+$mortal->command('@wait 9223372036854775807=think this should not run for decades');
+test('time64.relwait.1', $mortal, 'think gt(pidinfo(last(lpids()), time), 2000000000)', '^1$');
+$mortal->command('@halt/pid [last(lpids())]');


### PR DESCRIPTION
Penn's notion of time has always been 32-bit, which means things will get very bad in 2038. Given this codebase has made it 40+ years already, it's not unreasonable to think it will still be in use in 2038. This PR moves all time handling to 64-bit:

- **Main database**: object `created`/`modified` times were truncated to `int` on every dump and clamped at `INT_MAX` on load (corrupting `objid()`s among other things). They now serialize via new 64-bit `db_write_labeled_time()`/`putref_time()`/`getref_time()` helpers. Old databases load fine.
- **Softcode & commands**: `convsecs()`, `timefmt()`, `isdaylight()`, `connlog()`, `@wait/until`, and `@waitpid/until` now parse epochs with `parse_int64()` instead of the 32-bit `parse_integer()`. 
- **connlog**: the `timestamps` rtree_i32 virtual table is inherently 32-bit (SQLite has no 64-bit rtree), so it's replaced with a plain indexed table. Databases upgrade automatically (v1–v4 → v5, verified against fixtures built from each historical schema).
- **Windows**: reboot.db descriptor times, mail sender ctimes, and MSSP UPTIME went through 32-bit `long` on LLP64; now explicit 64-bit.

Tests: new `test/testtime64.t` covers the widened functions plus a post-2038 `@wait/until`; a year-2100 `created` value round-trips through db load → `csecs()`/`objid()`/`ctime()` → `@dump` intact. 

Note: arguably this might merit a point release instead of a patchlevel because the connlog schema change is one-way (albeit not catastrophic; a previous binary will just gracefully fail to use the connlog feature). Open to debate on that, since all prior schema changes happened in RCs - this is the first post-release connlog schema change. 

Supersedes #1428 (thanks @kaledin for the initial patch). 