### PR TITLE
Fix three player-triggerable crashes in softcode and `@halt/pid`

### DIFF
--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -37,6 +37,7 @@ Fixes
 * Telnet subnegotations displayed the subnegotation end character (SE) visibly for clients which had negotiated a unicode character set. Reported by Ben Gunderson. [1407, MG]
 * Fix for crashbug in @halt [1424,MT]
 * Repeating telnet characterset negotiation for a connection which had already negotiated as UTF-8 could cause a crash. From a report from Volund. [MG]
+* Fixed a crash in `floordiv()`, `modulo()` and `remainder()` with certain integer arguments. [TK]
 
 Version 1.8.8 patchlevel 0 Apr 20 2020
 ======================================

--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -39,6 +39,7 @@ Fixes
 * Repeating telnet characterset negotiation for a connection which had already negotiated as UTF-8 could cause a crash. From a report from Volund. [MG]
 * Fixed a crash in `floordiv()`, `modulo()` and `remainder()` with certain integer arguments. [TK]
 * Fixed a buffer overflow in `align()` and `lalign()`. [TK]
+* Fixed a potential use-after-free in `@halt/pid`. [TK]
 
 Version 1.8.8 patchlevel 0 Apr 20 2020
 ======================================

--- a/CHANGES.188.md
+++ b/CHANGES.188.md
@@ -38,6 +38,7 @@ Fixes
 * Fix for crashbug in @halt [1424,MT]
 * Repeating telnet characterset negotiation for a connection which had already negotiated as UTF-8 could cause a crash. From a report from Volund. [MG]
 * Fixed a crash in `floordiv()`, `modulo()` and `remainder()` with certain integer arguments. [TK]
+* Fixed a buffer overflow in `align()` and `lalign()`. [TK]
 
 Version 1.8.8 patchlevel 0 Apr 20 2020
 ======================================

--- a/src/cque.c
+++ b/src/cque.c
@@ -2315,6 +2315,7 @@ do_haltpid(dbref player, const char *arg1)
   q->executor = NOTHING;
   if (q->semaphore_attr) {
     MQUE *last = NULL, *tmp;
+    bool found = false;
     for (tmp = qsemfirst; tmp; last = tmp, tmp = tmp->next) {
       if (tmp == q) {
         if (last)
@@ -2323,13 +2324,20 @@ do_haltpid(dbref player, const char *arg1)
           qsemfirst = tmp->next;
         if (qsemlast == tmp)
           qsemlast = last;
+        found = true;
         break;
       }
     }
 
-    giveto(victim, QUEUE_COST);
-    add_to_sem(q->semaphore_obj, -1, q->semaphore_attr);
-    free_qentry(q);
+    /* Only clean up here if the entry is still waiting on the semaphore
+     * queue. If it has already been notified or timed out it has been moved
+     * to the normal queue (with semaphore_attr still set), where being flagged
+     * as halted is enough for it to be discarded safely. */
+    if (found) {
+      giveto(victim, QUEUE_COST);
+      add_to_sem(q->semaphore_obj, -1, q->semaphore_attr);
+      free_qentry(q);
+    }
   }
 
   notify_format(player, T("Queue entry with pid %u halted."),

--- a/src/funmath.c
+++ b/src/funmath.c
@@ -2185,7 +2185,7 @@ MATH_FUNC(math_floordiv)
       return;
     }
 
-    if (divresult == INT_MIN && temp == -1) {
+    if (divresult == INT64_MIN && temp == -1) {
       safe_str(T("#-1 DOMAIN ERROR"), buff, bp);
       return;
     }
@@ -2270,7 +2270,7 @@ MATH_FUNC(math_modulo)
       return;
     }
 
-    if (divresult == INT_MIN && temp == -1) {
+    if (divresult == INT64_MIN && temp == -1) {
       safe_str(T("#-1 DOMAIN ERROR"), buff, bp);
       return;
     }
@@ -2322,7 +2322,7 @@ MATH_FUNC(math_remainder)
       return;
     }
 
-    if (divresult == INT_MIN && temp == -1) {
+    if (divresult == INT64_MIN && temp == -1) {
       safe_str(T("#-1 DOMAIN ERROR"), buff, bp);
       return;
     }

--- a/src/funstr.c
+++ b/src/funstr.c
@@ -1994,6 +1994,10 @@ FUNCTION(fun_align)
   for (ptr = args[0]; *ptr; ptr++) {
     while (isspace(*ptr))
       ptr++;
+    if (ncols >= MAX_COLS) {
+      safe_str(T("#-1 TOO MANY COLUMNS FOR ALIGN"), buff, bp);
+      return;
+    }
     if (*ptr == '>') {
       calign[ncols] = AL_RIGHT;
       ptr++;


### PR DESCRIPTION
Fixes three memory-safety / crash bugs, each reachable by an ordinary
(non-wizard) player from softcode or a standard command.

### `floordiv()` / `modulo()` / `remainder()` — integer overflow
The guard for the `min-int / -1` overflow case compared the value against the
32-bit `INT_MIN` sentinel, but these operate on 64-bit integers, so the guard
never fired. This produced undefined behavior — and a `SIGFPE` server crash on
x86-64 — for the affected inputs, while also spuriously rejecting the (valid)
32-bit minimum. Corrected to `INT64_MIN`, matching the existing `div()` guard.

### `align()` / `lalign()` — out-of-bounds write
The column-specification parser wrote one entry per column into fixed-size
static arrays but only checked the column count *after* the parse loop had
already run, so a definition with more than the maximum number of columns
overran those arrays. The bound is now enforced inside the loop, before each
write.

### `@halt/pid` — use-after-free
`do_haltpid()` used the presence of a semaphore attribute to decide an entry
was still on the semaphore queue. An entry that had already been notified or
timed out is relocated to the normal queue with that attribute still set, so
the cleanup path could free an entry that was still linked in the run queue
(and double-decrement the semaphore). It now only performs that cleanup when
the entry is actually found on the semaphore queue; a relocated entry is left
flagged halted and discarded safely by the normal queue cycle.